### PR TITLE
Rename data_dir to be datadir

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -302,7 +302,7 @@ func (hc *hieraCfg) createHierarchyEntry(ic hieraapi.Invocation, name string, en
 	entry.initialize(ic, name, entryHash)
 	entryHash.EachPair(func(k, v px.Value) {
 		ks := k.String()
-		if ks == `data_dir` {
+		if ks == `datadir` {
 			entry.dataDir = v.String()
 		}
 		if utils.ContainsString(hieraapi.LocationKeys, ks) {

--- a/internal/init.go
+++ b/internal/init.go
@@ -22,7 +22,7 @@ func init() {
 				Optional[data_dig] => String[1],
 				Optional[data_hash] => String[1],
 				Optional[lookup_key] => String[1],
-				Optional[data_dir] => String[1],
+				Optional[datadir] => String[1],
 			}],
 			Entry => Struct[{
 				name => String[1],
@@ -30,7 +30,7 @@ func init() {
 				Optional[data_dig] => String[1],
 				Optional[data_hash] => String[1],
 				Optional[lookup_key] => String[1],
-				Optional[data_dir] => String[1],
+				Optional[datadir] => String[1],
 				Optional[path] => String[1],
 				Optional[paths] => Array[String[1], 1],
 				Optional[glob] => String[1],

--- a/internal/testdata/explicit/hiera.yaml
+++ b/internal/testdata/explicit/hiera.yaml
@@ -2,9 +2,9 @@ version: 5
 hierarchy:
   - name: Test 1
     data_hash: yaml_data
-    data_dir: hiera_data
+    datadir: hiera_data
     path: data.yaml
   - name: Test 2
     data_hash: json_data
-    data_dir: hiera_data
+    datadir: hiera_data
     path: data2.json


### PR DESCRIPTION
This is necessary for compatibility with the hiera 5 docs.
(Though it is inconsistent with the other keys, the benefit
of consistency with the existing implementation is more important)

Fixes #11 