### PR TITLE
Datadirs can now be absolute paths

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -140,7 +140,12 @@ func (e *entry) Resolve(ic hieraapi.Invocation, defaults hieraapi.Entry) hieraap
 		}
 	}
 
-	dataRoot := filepath.Join(e.cfg.root, ce.dataDir)
+	var dataRoot string
+	if filepath.IsAbs(ce.dataDir) {
+		dataRoot = ce.dataDir
+	} else {
+		dataRoot = filepath.Join(e.cfg.root, ce.dataDir)
+	}
 	if ce.locations != nil {
 		ne := make([]hieraapi.Location, 0, len(ce.locations))
 		for _, l := range ce.locations {


### PR DESCRIPTION
Previously, we prepended the config root onto the value
of datadir. If datadir was an absolute path, this would
lead to incorrect lookup locations:

  {"@level":"debug","@message":"location not found","@module":"lookup",
   "@timestamp":"2019-05-29T13:25:34.658470-07:00","context":"first found strategy",
   "key":"clusters.cb1","location":"path{ original:common.yaml,
   resolved:/Users/eric/Sandbox/lyra-local/tmp/Users/eric/Sandbox/lyra-local/tmp/hiera/common.yaml,
   exist:false}","provider":"data_hash function 'yaml_data'"
  }

This change tests for an absolute path in the datadir first and
only prepends the config root if needed.

Closes #17