### PR TITLE
Add lookup explanation support

### DIFF
--- a/explain/explainer.go
+++ b/explain/explainer.go
@@ -1,0 +1,66 @@
+package explain
+
+import (
+	"github.com/lyraproj/pcore/utils"
+
+	"github.com/lyraproj/hiera/hieraapi"
+	"github.com/lyraproj/pcore/px"
+)
+
+type Context int
+
+type Explainer interface {
+	utils.Indentable
+
+	// AcceptFound accepts information that a value was found for a given key
+	AcceptFound(key interface{}, value px.Value)
+
+	// AcceptFoundInDefaults accepts information that a value was found for a given key in the defaults hash
+	AcceptFoundInDefaults(key string, value px.Value)
+
+	// AcceptFoundInOverrides accepts information that a value was found for a given key in the overrides hash
+	AcceptFoundInOverrides(key string, value px.Value)
+
+	// AcceptLocationNotFound accepts information that a location was not found. The actual location is determined
+	// by the top explainer node of type Context "Location"
+	AcceptLocationNotFound()
+
+	// AcceptMergeSource accepts information that about as source for merge options such as the lookup_options hash
+	AcceptMergeSource(mergeSource string)
+
+	// AcceptNotFound accepts information that a key was not found
+	AcceptNotFound(key interface{})
+
+	// AcceptResult accepts information about the result of a merge
+	AcceptMergeResult(value px.Value)
+
+	// AcceptText accepts arbitrary text to be injected into the explanation
+	AcceptText(text string)
+
+	PushDataProvider(pvd hieraapi.DataProvider)
+
+	PushInterpolation(expr string)
+
+	PushInvalidKey(key interface{})
+
+	PushLocation(loc hieraapi.Location)
+
+	PushLookup(key hieraapi.Key)
+
+	PushMerge(mrg hieraapi.MergeStrategy)
+
+	PushSegment(seg interface{})
+
+	PushSubLookup(key hieraapi.Key)
+
+	// Pop pops an explainer node from the stack of explanations
+	Pop()
+
+	// OnlyOptions returns true if lookups of lookup_options is the only thing that will be included in the explanation
+	OnlyOptions() bool
+
+	// Options returns true if lookups of lookup_options will be included in the explanation
+	Options() bool
+}
+
+var NewExplainer func(options, onlyOptions bool) Explainer

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/hashicorp/go-hclog v0.9.0
 	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533
+	github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/hashicorp/go-hclog v0.9.0
 	github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594
-	github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658
+	github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533 h1:wfjjlWN0OIUcjOaAfqsgqzbu0+F3jY5cehtuKlPAjHA=
-github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
+github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291 h1:XrveF2dlFKU7Ngi0rF1kyHPGRAyMZDerAl9y9peA0ps=
+github.com/lyraproj/pcore v0.0.0-20190604153946-03f706b24291/go.mod h1:ZnU8IagnqPnmjQDz2DiQaQvkKZVYpdePETJpOY8BAo0=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
@@ -47,7 +47,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,8 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594 h1:IcsHRQ3xzCIcK0eXpot8IYgEyUQPEFHmFErZwJcsDqk=
 github.com/lyraproj/issue v0.0.0-20190513084509-faf9b542f594/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658 h1:t0Uf09WOnTYJ35RIO/R/D/qubjpVLr7BAa9qGAoP2ls=
-github.com/lyraproj/pcore v0.0.0-20190521101211-2b39bcf82658/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
+github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533 h1:wfjjlWN0OIUcjOaAfqsgqzbu0+F3jY5cehtuKlPAjHA=
+github.com/lyraproj/pcore v0.0.0-20190604084249-96c922091533/go.mod h1:NEsDhoJnhU6dqrNy3M2W4AWryrwPhADubXu6RWVdAl4=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/hiera/hiera.go
+++ b/hiera/hiera.go
@@ -3,14 +3,16 @@ package hiera
 import (
 	"context"
 
+	"github.com/lyraproj/hiera/explain"
+
 	"github.com/lyraproj/hiera/hieraapi"
 	"github.com/lyraproj/hiera/internal"
 	"github.com/lyraproj/pcore/pcore"
 	"github.com/lyraproj/pcore/px"
 )
 
-func NewInvocation(c px.Context, scope px.Keyed) hieraapi.Invocation {
-	return internal.NewInvocation(c, scope)
+func NewInvocation(c px.Context, scope px.Keyed, explainer explain.Explainer) hieraapi.Invocation {
+	return internal.NewInvocation(c, scope, explainer)
 }
 
 func Lookup(ic hieraapi.Invocation, name string, dflt px.Value, options map[string]px.Value) px.Value {

--- a/hiera/hiera_test.go
+++ b/hiera/hiera_test.go
@@ -23,28 +23,28 @@ func init() {
 
 func ExampleLookup_first() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `first`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `first`, nil, nil))
 	})
 	// Output: value of first
 }
 
 func ExampleLookup_dottedInt() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `array.1`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `array.1`, nil, nil))
 	})
 	// Output: two
 }
 
 func ExampleLookup_dottedMix() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `hash.array.1`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `hash.array.1`, nil, nil))
 	})
 	// Output: value of first
 }
 
 func ExampleLookup_interpolate() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `second`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `second`, nil, nil))
 	})
 	// Output: includes 'value of first'
 }
@@ -55,8 +55,8 @@ func ExampleLookup_interpolateScope() {
 			`world`: `cruel world`,
 		})
 		hiera.DoWithParent(c, provider.YamlLookupKey, options, func(c px.Context) {
-			fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `ipScope`, nil, nil))
-			fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `ipScope2`, nil, nil))
+			fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `ipScope`, nil, nil))
+			fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `ipScope2`, nil, nil))
 		})
 	})
 	// Output:
@@ -67,12 +67,12 @@ func ExampleLookup_interpolateScope() {
 func ExampleLookup_interpolateEmpty() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
 		s := px.EmptyMap
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty1`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty2`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty3`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty4`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty5`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s), `empty6`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty1`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty2`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty3`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty4`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty5`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, s, nil), `empty6`, nil, nil))
 	})
 	// Output:
 	// StartEnd
@@ -93,14 +93,14 @@ func printErr(e error) {
 
 func ExampleLookup_interpolateLiteral() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `ipLiteral`, nil, options))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `ipLiteral`, nil, options))
 	})
 	// Output: some literal text
 }
 
 func ExampleLookup_interpolateAlias() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		v := hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `ipAlias`, nil, options)
+		v := hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `ipAlias`, nil, options)
 		fmt.Printf(`%s %s`, px.GenericValueType(v), v)
 	})
 	// Output: Array[Enum] ['one', 'two', 'three']
@@ -108,7 +108,7 @@ func ExampleLookup_interpolateAlias() {
 
 func ExampleLookup_interpolateBadAlias() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `ipBadAlias`, nil, options)
+		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `ipBadAlias`, nil, options)
 		return nil
 	}))
 	// Output: 'alias' interpolation is only permitted if the expression is equal to the entire string
@@ -116,7 +116,7 @@ func ExampleLookup_interpolateBadAlias() {
 
 func ExampleLookup_interpolateBadFunction() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `ipBad`, nil, options)
+		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `ipBad`, nil, options)
 		return nil
 	}))
 	// Output: Unknown interpolation method 'bad'
@@ -124,7 +124,7 @@ func ExampleLookup_interpolateBadFunction() {
 
 func ExampleLookup_notFoundWithoutDefault() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `nonexistent`, nil, options)
+		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `nonexistent`, nil, options)
 		return nil
 	}))
 	// Output: lookup() did not find a value for the name 'nonexistent'
@@ -132,58 +132,58 @@ func ExampleLookup_notFoundWithoutDefault() {
 
 func ExampleLookup_notFoundDflt() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `nonexistent`, types.WrapString(`default value`), options))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `nonexistent`, types.WrapString(`default value`), options))
 	})
 	// Output: default value
 }
 
 func ExampleLookup_notFoundDottedIdx() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `array.3`, types.WrapString(`default value`), options))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `array.3`, types.WrapString(`default value`), options))
 	})
 	// Output: default value
 }
 
 func ExampleLookup_notFoundDottedMix() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `hash.float`, types.WrapString(`default value`), options))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `hash.float`, types.WrapString(`default value`), options))
 	})
 	// Output: default value
 }
 
 func ExampleLookup_badStringDig() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `hash.int.v`, nil, options)
+		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `hash.int.v`, nil, options)
 		return nil
 	}))
-	// Output: lookup() Got Integer when a hash-like object was expected to access value using 'v' from key 'hash.int.v'
+	// Output: lookup() did not find a value for the name 'hash.int.v'
 }
 
 func ExampleLookup_badIntDig() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `hash.int.3`, nil, options)
+		hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `hash.int.3`, nil, options)
 		return nil
 	}))
-	// Output: lookup() Got Integer when a hash-like object was expected to access value using '3' from key 'hash.int.3'
+	// Output: lookup() did not find a value for the name 'hash.int.3'
 }
 
 func ExampleLookup2_findFirst() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap), []string{`first`, `second`}, types.DefaultAnyType(), nil, nil, nil, options, nil))
+		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap, nil), []string{`first`, `second`}, types.DefaultAnyType(), nil, nil, nil, options, nil))
 	})
 	// Output: value of first
 }
 
 func ExampleLookup2_findSecond() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap), []string{`non existing`, `second`}, types.DefaultAnyType(), nil, nil, nil, options, nil))
+		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap, nil), []string{`non existing`, `second`}, types.DefaultAnyType(), nil, nil, nil, options, nil))
 	})
 	// Output: includes 'value of first'
 }
 
 func ExampleLookup2_notFoundWithoutDflt() {
 	printErr(hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) error {
-		hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap), []string{`non existing`, `not there`}, types.DefaultAnyType(), nil, nil, nil, options, nil)
+		hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap, nil), []string{`non existing`, `not there`}, types.DefaultAnyType(), nil, nil, nil, options, nil)
 		return nil
 	}))
 	// Output: lookup() did not find a value for any of the names [non existing, not there]
@@ -191,14 +191,14 @@ func ExampleLookup2_notFoundWithoutDflt() {
 
 func ExampleLookup2_notFoundDflt() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap), []string{`non existing`, `not there`}, types.DefaultAnyType(), types.WrapString(`default value`), nil, nil, options, nil))
+		fmt.Println(hiera.Lookup2(internal.NewInvocation(c, px.EmptyMap, nil), []string{`non existing`, `not there`}, types.DefaultAnyType(), types.WrapString(`default value`), nil, nil, options, nil))
 	})
 	// Output: default value
 }
 
 func ExampleLookup_dottedStringInt() {
 	hiera.DoWithParent(context.Background(), provider.YamlLookupKey, options, func(c px.Context) {
-		v := hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `hash.array.0`, nil, options)
+		v := hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `hash.array.0`, nil, options)
 		fmt.Println(v)
 	})
 	// Output: two
@@ -217,8 +217,8 @@ func ExampleLookup_mapProvider() {
 	}
 
 	hiera.DoWithParent(context.Background(), tp, map[string]px.Value{}, func(c px.Context) {
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `a`, nil, nil))
-		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap), `b`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `a`, nil, nil))
+		fmt.Println(hiera.Lookup(internal.NewInvocation(c, px.EmptyMap, nil), `b`, nil, nil))
 	})
 
 	// Output:

--- a/hieraapi/api.go
+++ b/hieraapi/api.go
@@ -93,20 +93,42 @@ type Invocation interface {
 	// Call doer and while it is executing, don't reveal any found values in logs
 	DoRedacted(doer px.Doer)
 
-	// Execute the given function 'f' in an explanation context named by 'n'
-	WithExplanationContext(n string, f func())
-
-	// Explain will add the message returned by the given function to the
+	// ReportText will add the message returned by the given function to the
 	// lookup explainer. The method will only get called when the explanation
 	// support is enabled
-	Explain(messageProducer func() string)
-
-	WithKey(key Key, value px.Producer) px.Value
-	WithDataProvider(dh DataProvider, value px.Producer) px.Value
-	WithLocation(loc Location, value px.Producer) px.Value
+	ReportText(messageProducer func() string)
 	ReportLocationNotFound()
-	ReportFound(value px.Value)
-	ReportNotFound()
+	ReportFound(key interface{}, value px.Value)
+	ReportMergeResult(value px.Value)
+	ReportMergeSource(source string)
+	ReportNotFound(key interface{})
+
+	WithDataProvider(pvd DataProvider, f px.Producer) px.Value
+
+	WithInterpolation(expr string, f px.Producer) px.Value
+
+	WithInvalidKey(key interface{}, f px.Producer) px.Value
+
+	WithLocation(loc Location, f px.Producer) px.Value
+
+	WithLookup(key Key, f px.Producer) px.Value
+
+	WithMerge(ms MergeStrategy, f px.Producer) px.Value
+
+	WithSegment(seg interface{}, f px.Producer) px.Value
+
+	WithSubLookup(key Key, f px.Producer) px.Value
+
+	// ForConfig returns an Invocation that without explainer support
+	ForConfig() Invocation
+
+	// ForData returns an Invocation that has adjusted its explainer according to
+	// how it should report lookup of data as opposed to the "lookup_options" key.
+	ForData() Invocation
+
+	// ForLookupOptions returns an Invocation that has adjusted its explainer according to
+	// how it should report lookup of the "lookup_options" key.
+	ForLookupOptions() Invocation
 }
 
 // NotFound is the error that Hiera will panic with when a value cannot be found and no default

--- a/hieraapi/key.go
+++ b/hieraapi/key.go
@@ -13,7 +13,7 @@ type Key interface {
 
 	// Return the result of using this key to dig into the given value. Nil is returned
 	// unless the dig was a success
-	Dig(px.Value) px.Value
+	Dig(Invocation, px.Value) px.Value
 
 	// Bury is the opposite of Dig. It returns the value that represents what would be found
 	// using the root of this key. If this key has one part, the value itself is returned, otherwise

--- a/hieraapi/mergestrategy.go
+++ b/hieraapi/mergestrategy.go
@@ -1,6 +1,7 @@
 package hieraapi
 
 import (
+	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
 )
 
@@ -10,8 +11,13 @@ var GetMergeStrategy func(name string, options map[string]px.Value) MergeStrateg
 
 // MergeStrategy is responsible for merging or prioritizing the result of several lookups into one.
 type MergeStrategy interface {
+	issue.Labeled
+
 	// Lookup performs a series of lookups for each variant found in the given variants slice. The actual
 	// lookup value is returned by the given value function which will be called at least once. The argument to
 	// the value function will be an element of the variants slice.
 	Lookup(variants interface{}, invocation Invocation, value func(location interface{}) px.Value) px.Value
+
+	// Options returns the options for this strategy or an empty map if strategy has no options
+	Options() px.OrderedMap
 }

--- a/hieraapi/providercontext.go
+++ b/hieraapi/providercontext.go
@@ -17,7 +17,7 @@ type ProviderContext interface {
 	// Lookup logic. There is no return from this method.
 	NotFound()
 
-	// Explain will add the message returned by the given function to the
+	// ReportText will add the message returned by the given function to the
 	// lookup explainer. The method will only get called when the explanation
 	// support is enabled
 	Explain(messageProducer func() string)

--- a/hieraapi/providercontext_test.go
+++ b/hieraapi/providercontext_test.go
@@ -28,7 +28,7 @@ func ExampleProviderContext_CachedValue() {
 			`a`: `scope 'a'`,
 			`b`: `scope 'b'`,
 		})
-		ic := hiera.NewInvocation(c, s)
+		ic := hiera.NewInvocation(c, s, nil)
 		fmt.Println(hiera.Lookup(ic, `a`, nil, nil))
 		fmt.Println(hiera.Lookup(ic, `b`, nil, nil))
 		fmt.Println(hiera.Lookup(ic, `a`, nil, nil))

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -20,7 +20,7 @@ func TestConfigLookup_default(t *testing.T) {
 	require.NoError(t, err)
 	options := map[string]px.Value{hieraapi.HieraRoot: types.WrapString(filepath.Join(wd, `testdata`, `defaultconfig`))}
 	hiera.DoWithParent(context.Background(), nil, options, func(c px.Context) {
-		require.Equal(t, `value of first`, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap), `first`, nil, nil).String())
+		require.Equal(t, `value of first`, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap, nil), `first`, nil, nil).String())
 	})
 }
 
@@ -30,7 +30,7 @@ func TestConfigLookup_lyra_default(t *testing.T) {
 	require.NoError(t, err)
 	options := map[string]px.Value{hieraapi.HieraRoot: types.WrapString(filepath.Join(wd, `testdata`, `defaultlyraconfig`))}
 	hiera.DoWithParent(context.Background(), nil, options, func(c px.Context) {
-		require.Equal(t, `value of first`, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap), `first`, nil, nil).String())
+		require.Equal(t, `value of first`, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap, nil), `first`, nil, nil).String())
 	})
 }
 
@@ -69,6 +69,6 @@ func testExplicit(t *testing.T, key, merge, expected string) {
 		luOpts = map[string]px.Value{`merge`: types.WrapString(merge)}
 	}
 	hiera.DoWithParent(context.Background(), nil, options, func(c px.Context) {
-		require.Equal(t, expected, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap), key, nil, luOpts).String())
+		require.Equal(t, expected, hiera.Lookup(hiera.NewInvocation(c, px.EmptyMap, nil), key, nil, luOpts).String())
 	})
 }

--- a/internal/datahashprovider.go
+++ b/internal/datahashprovider.go
@@ -42,9 +42,10 @@ func (dh *DataHashProvider) invokeWithLocation(invocation hieraapi.Invocation, l
 
 func (dh *DataHashProvider) lookupKey(invocation hieraapi.Invocation, location hieraapi.Location, root string) px.Value {
 	if value := dh.dataValue(invocation, location, root); value != nil {
-		invocation.ReportFound(value)
+		invocation.ReportFound(root, value)
 		return value
 	}
+	invocation.ReportNotFound(root)
 	return nil
 }
 
@@ -93,7 +94,7 @@ func (dh *DataHashProvider) providerFunction(ic hieraapi.Invocation) (pf hieraap
 				return
 			}
 		} else {
-			ic.Explain(func() string {
+			ic.ReportText(func() string {
 				return fmt.Sprintf(`unresolved function '%s'`, dh.function.Name())
 			})
 			dh.providerFunc = func(pc hieraapi.ProviderContext, options map[string]px.Value) px.OrderedMap {

--- a/internal/explainer.go
+++ b/internal/explainer.go
@@ -1,0 +1,494 @@
+package internal
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/lyraproj/hiera/explain"
+
+	"github.com/lyraproj/pcore/utils"
+
+	"github.com/lyraproj/hiera/hieraapi"
+	"github.com/lyraproj/pcore/px"
+)
+
+func init() {
+	explain.NewExplainer = newExplainer
+}
+
+type event int
+
+const (
+	found = event(iota) + 1
+	foundInDefaults
+	foundInOverrides
+	locationNotFound
+	notFound
+	result
+)
+
+type explainNode interface {
+	utils.Indentable
+	appendBranch(branch explainNode)
+	appendText(text string)
+	branches() []explainNode
+	event() event
+	found(key interface{}, v px.Value)
+	foundInDefaults(key interface{}, v px.Value)
+	foundInOverrides(key interface{}, v px.Value)
+	key() string
+	locationNotFound()
+	notFound(k interface{})
+	parent() explainNode
+	result(result px.Value)
+	texts() []string
+	value() px.Value
+}
+
+type explainTreeNode struct {
+	p  explainNode
+	bs []explainNode
+	ts []string
+	e  event
+	v  px.Value
+	k  string
+}
+
+func keyToString(k interface{}) string {
+	switch k := k.(type) {
+	case string:
+		return k
+	case int:
+		return strconv.Itoa(k)
+	case fmt.Stringer:
+		return k.String()
+	default:
+		return fmt.Sprintf(`%v`, k)
+	}
+}
+
+func (en *explainTreeNode) AppendTo(w *utils.Indenter) {
+	en.dumpTexts(w)
+}
+
+func (en *explainTreeNode) appendBranch(branch explainNode) {
+	en.bs = append(en.bs, branch)
+}
+
+func (en *explainTreeNode) appendText(text string) {
+	en.ts = append(en.ts, text)
+}
+
+func (en *explainTreeNode) branches() []explainNode {
+	return en.bs
+}
+
+func (en *explainTreeNode) dumpOutcome(w *utils.Indenter) {
+	switch en.e {
+	case notFound:
+		w.NewLine()
+		w.Append(`No such key: "`)
+		w.Append(en.k)
+		w.AppendRune('"')
+	case found, foundInDefaults, foundInOverrides:
+		w.NewLine()
+		w.Append(`Found key: "`)
+		w.Append(en.k)
+		w.Append(`" value: `)
+		dumpValue(en.v, w)
+		if en.e == foundInDefaults {
+			w.Append(` in defaults`)
+		} else if en.e == foundInOverrides {
+			w.Append(` in overrides`)
+		}
+	}
+	en.dumpTexts(w)
+}
+
+func dumpValue(v px.Value, w *utils.Indenter) {
+	w.AppendIndented(px.ToPrettyString(v))
+}
+
+func (en *explainTreeNode) dumpTexts(w *utils.Indenter) {
+	for _, t := range en.ts {
+		w.NewLine()
+		w.Append(t)
+	}
+}
+
+func (en *explainTreeNode) dumpBranches(w *utils.Indenter) {
+	for _, b := range en.bs {
+		b.AppendTo(w)
+	}
+}
+
+func (en *explainTreeNode) event() event {
+	return en.e
+}
+
+func (en *explainTreeNode) found(key interface{}, v px.Value) {
+	en.k = keyToString(key)
+	en.v = v
+	en.e = found
+}
+
+func (en *explainTreeNode) foundInDefaults(key interface{}, v px.Value) {
+	en.k = keyToString(key)
+	en.v = v
+	en.e = foundInDefaults
+}
+
+func (en *explainTreeNode) foundInOverrides(key interface{}, v px.Value) {
+	en.k = keyToString(key)
+	en.v = v
+	en.e = foundInOverrides
+}
+
+func (en *explainTreeNode) key() string {
+	return en.k
+}
+
+func (en *explainTreeNode) locationNotFound() {
+	en.e = locationNotFound
+}
+
+func (en *explainTreeNode) notFound(k interface{}) {
+	en.k = keyToString(k)
+	en.e = notFound
+}
+
+func (en *explainTreeNode) result(v px.Value) {
+	en.v = v
+	en.e = result
+}
+
+func (en *explainTreeNode) parent() explainNode {
+	return en.p
+}
+
+func (en *explainTreeNode) texts() []string {
+	return en.ts
+}
+
+func (en *explainTreeNode) value() px.Value {
+	return en.v
+}
+
+type explainDataProvider struct {
+	explainTreeNode
+	provider hieraapi.DataProvider
+}
+
+func (en *explainDataProvider) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	w.Append(en.provider.FullName())
+	w = w.Indent()
+	en.dumpBranches(w)
+	en.dumpOutcome(w)
+}
+
+func (en *explainDataProvider) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainInterpolate struct {
+	explainTreeNode
+	expression string
+}
+
+func (en *explainInterpolate) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	w.Append(`Interpolation on "`)
+	w.Append(en.expression)
+	w.AppendRune('"')
+	en.dumpBranches(w.Indent())
+}
+
+func (en *explainInterpolate) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainInvalidKey struct {
+	explainTreeNode
+}
+
+func (en *explainInvalidKey) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	w.Append(`Invalid key "`)
+	w.Append(en.key())
+	w.AppendRune('"')
+}
+
+func (en *explainInvalidKey) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainKeySegment struct {
+	explainTreeNode
+	segment interface{}
+}
+
+func (en *explainKeySegment) AppendTo(w *utils.Indenter) {
+	en.dumpOutcome(w)
+}
+
+func (en *explainKeySegment) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainLocation struct {
+	explainTreeNode
+	location hieraapi.Location
+}
+
+func (en *explainLocation) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	if en.location.Kind() == hieraapi.LcPath {
+		w.Append(`Path "`)
+	} else {
+		w.Append(`URI "`)
+	}
+	w.Append(en.location.Resolved())
+	w.AppendRune('"')
+
+	w = w.Indent()
+	w.NewLine()
+	w.Append(`Original `)
+	w.Append(string(en.location.Kind()))
+	w.Append(`: "`)
+	w.Append(en.location.Original())
+	w.AppendRune('"')
+
+	en.dumpBranches(w)
+	if en.e == notFound {
+		w.NewLine()
+		w.Append(string(en.location.Kind()))
+		w.Append(` not found`)
+	}
+	en.dumpOutcome(w)
+}
+
+func (en *explainLocation) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainLookup struct {
+	explainTreeNode
+}
+
+func (en *explainLookup) AppendTo(w *utils.Indenter) {
+	if w.Len() > 0 || w.Level() > 0 {
+		w.NewLine()
+	}
+	w.Append(`Searching for "`)
+	w.Append(en.key())
+	w.AppendRune('"')
+	en.dumpBranches(w.Indent())
+}
+
+func (en *explainLookup) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainMerge struct {
+	explainTreeNode
+	merge hieraapi.MergeStrategy
+}
+
+func (en *explainMerge) AppendTo(w *utils.Indenter) {
+	switch len(en.bs) {
+	case 0:
+		// No action
+	case 1:
+		en.bs[0].AppendTo(w)
+	default:
+		w.NewLine()
+		w.Append(`Merge strategy "`)
+		w.Append(en.merge.Label())
+		w.AppendRune('"')
+		w = w.Indent()
+		opts := en.merge.Options()
+		if !opts.IsEmpty() {
+			w.NewLine()
+			w.Append(`Options: `)
+			dumpValue(opts, w.Indent())
+		}
+		en.dumpBranches(w)
+		if en.e == result {
+			w.NewLine()
+			w.Append(`Merged result: `)
+			dumpValue(en.v, w.Indent())
+		}
+	}
+}
+
+func (en *explainMerge) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainMergeSource struct {
+	explainTreeNode
+	mergeSource string
+}
+
+func (en *explainMergeSource) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	w.Append(`Using merge options from `)
+	w.Append(en.mergeSource)
+}
+
+func (en *explainMergeSource) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainSubLookup struct {
+	explainTreeNode
+	subKey hieraapi.Key
+}
+
+func (en *explainSubLookup) AppendTo(w *utils.Indenter) {
+	w.NewLine()
+	w.Append(`Sub key: "`)
+	for i, s := range en.subKey.Parts()[1:] {
+		if i > 0 {
+			w.AppendRune('.')
+		}
+		w.Append(keyToString(s))
+	}
+	w.AppendRune('"')
+	w = w.Indent()
+	en.dumpBranches(w)
+	en.dumpOutcome(w)
+}
+
+func (en *explainSubLookup) String() string {
+	return utils.IndentedString(en)
+}
+
+type explainer struct {
+	explainTreeNode
+	current     explainNode
+	options     bool
+	onlyOptions bool
+}
+
+func newExplainer(options, onlyOptions bool) explain.Explainer {
+	ex := &explainer{options: options, onlyOptions: onlyOptions}
+	ex.current = ex
+	return ex
+}
+
+func (ex *explainer) AcceptFound(key interface{}, value px.Value) {
+	ex.current.found(key, value)
+}
+
+func (ex *explainer) AcceptFoundInDefaults(key string, value px.Value) {
+	ex.current.foundInDefaults(key, value)
+}
+
+func (ex *explainer) AcceptFoundInOverrides(key string, value px.Value) {
+	ex.current.foundInOverrides(key, value)
+}
+
+func (ex *explainer) AcceptLocationNotFound() {
+	ex.current.locationNotFound()
+}
+
+func (ex *explainer) AcceptMergeSource(mergeSource string) {
+	en := &explainMergeSource{mergeSource: mergeSource}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+}
+
+func (ex *explainer) AcceptNotFound(key interface{}) {
+	ex.current.notFound(key)
+}
+
+func (ex *explainer) AcceptMergeResult(value px.Value) {
+	ex.current.result(value)
+}
+
+func (ex *explainer) AcceptText(text string) {
+	ex.current.appendText(text)
+}
+
+func (ex *explainer) PushDataProvider(pvd hieraapi.DataProvider) {
+	en := &explainDataProvider{provider: pvd}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushInterpolation(expr string) {
+	en := &explainInterpolate{expression: expr}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushInvalidKey(key interface{}) {
+	en := &explainInvalidKey{}
+	en.k = keyToString(key)
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushLocation(loc hieraapi.Location) {
+	en := &explainLocation{location: loc}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushLookup(key hieraapi.Key) {
+	en := &explainLookup{}
+	en.p = ex.current
+	en.k = keyToString(key)
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushMerge(mrg hieraapi.MergeStrategy) {
+	en := &explainMerge{merge: mrg}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushSegment(seg interface{}) {
+	en := &explainKeySegment{segment: seg}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) PushSubLookup(key hieraapi.Key) {
+	en := &explainSubLookup{subKey: key}
+	en.p = ex.current
+	ex.current.appendBranch(en)
+	ex.current = en
+}
+
+func (ex *explainer) Pop() {
+	if ex.current != nil {
+		ex.current = ex.current.parent()
+	}
+}
+
+func (ex *explainer) OnlyOptions() bool {
+	return ex.onlyOptions
+}
+
+func (ex *explainer) Options() bool {
+	return ex.options
+}
+
+func (ex *explainer) AppendTo(w *utils.Indenter) {
+	ex.dumpBranches(w)
+	ex.dumpTexts(w)
+}
+
+func (ex *explainer) String() string {
+	return utils.IndentedString(ex)
+}

--- a/internal/init.go
+++ b/internal/init.go
@@ -83,10 +83,7 @@ func Lookup2(
 		if ov, ok := override.Get4(name); ok {
 			return ov
 		}
-		key := newKey(name)
-		v := ic.WithKey(key, func() px.Value {
-			return ic.(*invocation).lookupViaCache(key, options)
-		})
+		v := ic.(*invocation).lookupViaCache(newKey(name), options)
 		if v != nil {
 			return v
 		}

--- a/internal/key.go
+++ b/internal/key.go
@@ -34,7 +34,9 @@ func (k *key) Dig(ic hieraapi.Invocation, v px.Value) px.Value {
 				case *types.Array:
 					if ix, ok := p.(int); ok {
 						if ix >= 0 && ix < vc.Len() {
-							return vc.At(ix)
+							v = vc.At(ix)
+							ic.ReportFound(p, v)
+							return v
 						}
 					}
 				case *types.Hash:
@@ -45,6 +47,7 @@ func (k *key) Dig(ic hieraapi.Invocation, v px.Value) px.Value {
 						kx = types.WrapString(p.(string))
 					}
 					if v, ok := vc.Get(kx); ok {
+						ic.ReportFound(p, v)
 						return v
 					}
 				}

--- a/internal/key.go
+++ b/internal/key.go
@@ -20,35 +20,43 @@ func newKey(str string) hieraapi.Key {
 	return &key{str, parseUnquoted(b, str, str, []interface{}{})}
 }
 
-func (k *key) Dig(v px.Value) px.Value {
-	var ok bool
-	var ix int
-	for i := 1; i < len(k.parts); i++ {
-		p := k.parts[i]
-		switch vc := v.(type) {
-		case *types.Array:
-			if ix, ok = p.(int); ok {
-				if ix >= 0 && ix < vc.Len() {
-					v = vc.At(ix)
-					continue
-				}
-				return nil
-			}
-		case *types.Hash:
-			var kx px.Value
-			if ix, ok = p.(int); ok {
-				kx = types.WrapInteger(int64(ix))
-			} else {
-				kx = types.WrapString(p.(string))
-			}
-			if v, ok = vc.Get(kx); ok {
-				continue
-			}
-			return nil
-		}
-		panic(px.Error(hieraapi.DigMismatch, issue.H{`type`: px.GenericValueType(v), `segment`: p, `key`: k.orig}))
+func (k *key) Dig(ic hieraapi.Invocation, v px.Value) px.Value {
+	t := len(k.parts)
+	if t == 1 {
+		return v
 	}
-	return v
+
+	return ic.WithSubLookup(k, func() px.Value {
+		for i := 1; i < t; i++ {
+			p := k.parts[i]
+			v = ic.WithSegment(p, func() px.Value {
+				switch vc := v.(type) {
+				case *types.Array:
+					if ix, ok := p.(int); ok {
+						if ix >= 0 && ix < vc.Len() {
+							return vc.At(ix)
+						}
+					}
+				case *types.Hash:
+					var kx px.Value
+					if ix, ok := p.(int); ok {
+						kx = types.WrapInteger(int64(ix))
+					} else {
+						kx = types.WrapString(p.(string))
+					}
+					if v, ok := vc.Get(kx); ok {
+						return v
+					}
+				}
+				ic.ReportNotFound(p)
+				return nil
+			})
+			if v == nil {
+				break
+			}
+		}
+		return v
+	})
 }
 
 func (k *key) Bury(value px.Value) px.Value {

--- a/internal/lookup.go
+++ b/internal/lookup.go
@@ -68,7 +68,7 @@ func init() {
 						options = mergeType(args[2])
 					}
 				}
-				return Lookup2(NewInvocation(c, c.Scope()), luNames(args[0]), vt, nil, nil, nil, options, nil)
+				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, nil, nil, nil, options, nil)
 			})
 		},
 
@@ -83,7 +83,7 @@ func init() {
 					vt = arg.(px.Type)
 				}
 				options := mergeType(args[2])
-				return Lookup2(NewInvocation(c, c.Scope()), luNames(args[0]), vt, args[3], nil, nil, options, nil)
+				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, args[3], nil, nil, options, nil)
 			})
 		},
 
@@ -98,7 +98,7 @@ func init() {
 					vt = arg.(px.Type)
 				}
 				options := mergeType(args[2])
-				return Lookup2(NewInvocation(c, c.Scope()), luNames(args[0]), vt, nil, nil, nil, options, block)
+				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, nil, nil, nil, options, block)
 			})
 		},
 
@@ -113,7 +113,7 @@ func init() {
 				override := hash.Get5(`override`, px.EmptyMap).(px.OrderedMap)
 				dfltHash := hash.Get5(`default_values_hash`, px.EmptyMap).(px.OrderedMap)
 				options := mergeType(hash.Get5(`merge`, px.Undef))
-				return Lookup2(NewInvocation(c, c.Scope()), names, vt, dflt, override, dfltHash, options, block)
+				return Lookup2(NewInvocation(c, c.Scope(), nil), names, vt, dflt, override, dfltHash, options, block)
 			})
 		},
 
@@ -129,7 +129,7 @@ func init() {
 				override := hash.Get5(`override`, px.EmptyMap).(px.OrderedMap)
 				dfltHash := hash.Get5(`default_values_hash`, px.EmptyMap).(px.OrderedMap)
 				options := mergeType(hash.Get5(`merge`, px.Undef))
-				return Lookup2(NewInvocation(c, c.Scope()), names, vt, dflt, override, dfltHash, options, block)
+				return Lookup2(NewInvocation(c, c.Scope(), nil), names, vt, dflt, override, dfltHash, options, block)
 			})
 		},
 	)

--- a/internal/lookup.go
+++ b/internal/lookup.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"github.com/hashicorp/go-hclog"
+	"github.com/lyraproj/hiera/explain"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
 )
@@ -27,6 +29,13 @@ func mergeType(nameOrHash px.Value) (merge map[string]px.Value) {
 		merge = map[string]px.Value{`merge`: nameOrHash}
 	}
 	return
+}
+
+func debugExplainer() explain.Explainer {
+	if hclog.Default().IsDebug() {
+		return explain.NewExplainer(false, false)
+	}
+	return nil
 }
 
 func init() {
@@ -60,15 +69,15 @@ func init() {
 			d.OptionalParam(`MergeType`)
 			d.Function(func(c px.Context, args []px.Value) px.Value {
 				vt := px.Type(types.DefaultAnyType())
-				var options map[string]px.Value
+				var options px.Value
 				argc := len(args)
 				if argc > 1 {
 					vt = args[1].(px.Type)
 					if argc > 2 {
-						options = mergeType(args[2])
+						options = args[2]
 					}
 				}
-				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, nil, nil, nil, options, nil)
+				return invokeLookup(c, luNames(args[0]), vt, nil, nil, nil, options, nil)
 			})
 		},
 
@@ -82,8 +91,7 @@ func init() {
 				if arg := args[1]; arg != px.Undef {
 					vt = arg.(px.Type)
 				}
-				options := mergeType(args[2])
-				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, args[3], nil, nil, options, nil)
+				return invokeLookup(c, luNames(args[0]), vt, args[3], nil, nil, args[2], nil)
 			})
 		},
 
@@ -97,8 +105,7 @@ func init() {
 				if arg := args[1]; arg != px.Undef {
 					vt = arg.(px.Type)
 				}
-				options := mergeType(args[2])
-				return Lookup2(NewInvocation(c, c.Scope(), nil), luNames(args[0]), vt, nil, nil, nil, options, block)
+				return invokeLookup(c, luNames(args[0]), vt, nil, nil, nil, args[2], block)
 			})
 		},
 
@@ -112,8 +119,7 @@ func init() {
 				vt := hash.Get5(`value_type`, types.DefaultAnyType()).(px.Type)
 				override := hash.Get5(`override`, px.EmptyMap).(px.OrderedMap)
 				dfltHash := hash.Get5(`default_values_hash`, px.EmptyMap).(px.OrderedMap)
-				options := mergeType(hash.Get5(`merge`, px.Undef))
-				return Lookup2(NewInvocation(c, c.Scope(), nil), names, vt, dflt, override, dfltHash, options, block)
+				return invokeLookup(c, names, vt, dflt, override, dfltHash, hash.Get5(`merge`, px.Undef), block)
 			})
 		},
 
@@ -128,9 +134,17 @@ func init() {
 				vt := hash.Get5(`value_type`, types.DefaultAnyType()).(px.Type)
 				override := hash.Get5(`override`, px.EmptyMap).(px.OrderedMap)
 				dfltHash := hash.Get5(`default_values_hash`, px.EmptyMap).(px.OrderedMap)
-				options := mergeType(hash.Get5(`merge`, px.Undef))
-				return Lookup2(NewInvocation(c, c.Scope(), nil), names, vt, dflt, override, dfltHash, options, block)
+				return invokeLookup(c, names, vt, dflt, override, dfltHash, hash.Get5(`merge`, px.Undef), block)
 			})
 		},
 	)
+}
+
+func invokeLookup(c px.Context, names []string, vt px.Type, dflt px.Value, override, dfltHash px.OrderedMap, options px.Value, block px.Lambda) px.Value {
+	ex := debugExplainer()
+	v := Lookup2(NewInvocation(c, c.Scope(), ex), names, vt, dflt, override, dfltHash, mergeType(options), block)
+	if ex != nil {
+		hclog.Default().Debug(ex.String())
+	}
+	return v
 }

--- a/internal/lookup.go
+++ b/internal/lookup.go
@@ -69,7 +69,7 @@ func init() {
 			d.OptionalParam(`MergeType`)
 			d.Function(func(c px.Context, args []px.Value) px.Value {
 				vt := px.Type(types.DefaultAnyType())
-				var options px.Value
+				options := px.Undef
 				argc := len(args)
 				if argc > 1 {
 					vt = args[1].(px.Type)

--- a/internal/lookupkeyprovider.go
+++ b/internal/lookupkeyprovider.go
@@ -50,7 +50,9 @@ func (dh *LookupKeyProvider) lookupKey(ic hieraapi.Invocation, location hieraapi
 	cache, _ := dh.hashes.LoadOrStore(key, &sync.Map{})
 	value := dh.providerFunction(ic)(newProviderContext(ic, cache.(*sync.Map)), root, opts)
 	if value != nil {
-		ic.ReportFound(value)
+		ic.ReportFound(root, value)
+	} else {
+		ic.ReportNotFound(root)
 	}
 	return value
 }
@@ -68,7 +70,7 @@ func (dh *LookupKeyProvider) providerFunction(ic hieraapi.Invocation) (pf hieraa
 				return f.(px.Function).Call(ic, nil, []px.Value{pc, types.WrapString(key), px.Wrap(ic, options)}...)
 			}
 		} else {
-			ic.Explain(func() string {
+			ic.ReportText(func() string {
 				return fmt.Sprintf(`unresolved function '%s'`, n)
 			})
 			dh.providerFunc = func(pc hieraapi.ProviderContext, key string, options map[string]px.Value) px.Value {

--- a/internal/providerctx.go
+++ b/internal/providerctx.go
@@ -113,7 +113,7 @@ func (c *providerCtx) NotFound() {
 }
 
 func (c *providerCtx) Explain(messageProducer func() string) {
-	c.invocation.Explain(messageProducer)
+	c.invocation.ReportText(messageProducer)
 }
 
 func (c *providerCtx) Cache(key string, value px.Value) px.Value {

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -83,6 +83,7 @@ func TestLookup_explain(t *testing.T) {
         Original path: "named_%{data_file}.yaml"
         Interpolation on "This is %\{c\.a\}"
           Sub key: "a"
+            Found key: "a" value: 'value of c.a'
         Found key: "interpolate_ca" value: 'This is value of c\.a'
     Merged result: 'This is value of c\.a'
 \z`, string(result))

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -66,6 +66,133 @@ func TestLookup_fact_interpolated_config(t *testing.T) {
 	})
 }
 
+func TestLookup_explain(t *testing.T) {
+	inTestdata(func() {
+		result, err := executeLookup(`--explain`, `--facts`, `facts.yaml`, `interpolate_ca`)
+		require.NoError(t, err)
+		require.Regexp(t,
+			`\ASearching for "interpolate_ca"
+  Merge strategy "first found strategy"
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/common\.yaml"
+        Original path: "common\.yaml"
+        path not found
+        No such key: "interpolate_ca"
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/named_by_fact\.yaml"
+        Original path: "named_%{data_file}.yaml"
+        Interpolation on "This is %\{c\.a\}"
+          Sub key: "a"
+        Found key: "interpolate_ca" value: 'This is value of c\.a'
+    Merged result: 'This is value of c\.a'
+\z`, string(result))
+	})
+}
+
+func TestLookup_explain_options(t *testing.T) {
+	inTestdata(func() {
+		result, err := executeLookup(`--explain-options`, `--facts`, `facts.yaml`, `hash`)
+		require.NoError(t, err)
+		require.Regexp(t,
+			`\ASearching for "lookup_options"
+  Merge strategy "deep merge strategy"
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/common\.yaml"
+        Original path: "common\.yaml"
+        Found key: "lookup_options" value: \{
+          'hash' => \{
+            'merge' => 'deep'
+          \},
+          'sense' => \{
+            'convert_to' => 'Sensitive'
+          \}
+        \}
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/named_by_fact\.yaml"
+        Original path: "named_%\{data_file\}\.yaml"
+        path not found
+        No such key: "lookup_options"
+    Merged result: \{
+        'hash' => \{
+          'merge' => 'deep'
+        \},
+        'sense' => \{
+          'convert_to' => 'Sensitive'
+        \}
+      \}
+\z`, string(result))
+	})
+}
+
+func TestLookup_explain_explain_options(t *testing.T) {
+	inTestdata(func() {
+		result, err := executeLookup(`--explain`, `--explain-options`, `--facts`, `facts.yaml`, `hash`)
+		require.NoError(t, err)
+		require.Regexp(t,
+			`\ASearching for "lookup_options"
+  Merge strategy "deep merge strategy"
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/common\.yaml"
+        Original path: "common\.yaml"
+        Found key: "lookup_options" value: \{
+          'hash' => \{
+            'merge' => 'deep'
+          \},
+          'sense' => \{
+            'convert_to' => 'Sensitive'
+          \}
+        \}
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/named_by_fact\.yaml"
+        Original path: "named_%\{data_file\}\.yaml"
+        path not found
+        No such key: "lookup_options"
+    Merged result: \{
+        'hash' => \{
+          'merge' => 'deep'
+        \},
+        'sense' => \{
+          'convert_to' => 'Sensitive'
+        \}
+      \}
+Searching for "hash"
+  Using merge options from "lookup_options" hash
+  Merge strategy "deep merge strategy"
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/common\.yaml"
+        Original path: "common\.yaml"
+        Found key: "hash" value: \{
+          'one' => 1,
+          'two' => 'two',
+          'three' => \{
+            'a' => 'A',
+            'c' => 'C'
+          \}
+        \}
+    data_hash function 'yaml_data'
+      Path "[^"]*/testdata/hiera/named_by_fact\.yaml"
+        Original path: "named_%\{data_file\}\.yaml"
+        Found key: "hash" value: \{
+          'one' => 'overwritten one',
+          'three' => \{
+            'a' => 'overwritten A',
+            'b' => 'B',
+            'c' => 'overwritten C'
+          \}
+        \}
+    Merged result: \{
+        'one' => 1,
+        'two' => 'two',
+        'three' => \{
+          'a' => 'A',
+          'c' => 'C',
+          'b' => 'B'
+        \}
+      \}
+\z`, string(result))
+	})
+}
+
 func inTestdata(f func()) {
 	cw, err := os.Getwd()
 	if err == nil {

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -1,1 +1,21 @@
 interpolate_a: 'This is %{a}'
+
+hash:
+  one: 1
+  two: two
+  three:
+    a: A
+    c: C
+
+array:
+  - one
+  - two
+  - three
+
+sense: Don't reveal this
+
+lookup_options:
+  hash:
+    merge: deep
+  sense:
+    convert_to: Sensitive

--- a/lookup/testdata/hiera/named_by_fact.yaml
+++ b/lookup/testdata/hiera/named_by_fact.yaml
@@ -1,1 +1,8 @@
 interpolate_ca: 'This is %{c.a}'
+
+hash:
+  one: overwritten one
+  three:
+    a: overwritten A
+    b: B
+    c: overwritten C

--- a/provider/configlookupkey.go
+++ b/provider/configlookupkey.go
@@ -13,82 +13,91 @@ var first = types.WrapString(`first`)
 func ConfigLookupKey(pc hieraapi.ProviderContext, key string, options map[string]px.Value) px.Value {
 	ic := pc.Invocation()
 	cfg := ic.Config()
+	ic = ic.ForData()
+
 	k := hieraapi.NewKey(key)
-	lo := cfg.LookupOptions(k)
-	merge, ok := options[`merge`]
-	if !ok {
-		if lo == nil {
-			merge = first
+	return ic.WithLookup(k, func() px.Value {
+		var lo map[string]px.Value
+		merge, ok := options[`merge`]
+		if ok {
+			ic.ReportMergeSource(`CLI option`)
 		} else {
-			merge, ok = lo[`merge`]
-			if !ok {
+			lo = cfg.LookupOptions(k)
+			if lo == nil {
 				merge = first
-			}
-		}
-	}
-
-	var mh px.OrderedMap
-	var mergeOpts map[string]px.Value
-	if mh, ok = merge.(px.OrderedMap); ok {
-		merge = mh.Get5(`strategy`, first)
-		mergeOpts = make(map[string]px.Value, mh.Len())
-		mh.EachPair(func(k, v px.Value) {
-			ks := k.String()
-			if ks != `strategy` {
-				mergeOpts[ks] = v
-			}
-		})
-	}
-
-	redacted := false
-
-	var convertToType px.Type
-	var convertToArgs []px.Value
-	if lo != nil {
-		ts := ``
-		if ct, ok := lo[`convert_to`]; ok {
-			if cm, ok := ct.(*types.Array); ok {
-				// First arg must be a type. The rest is arguments
-				switch cm.Len() {
-				case 0:
-					// Obviously bogus
-				case 1:
-					ts = cm.At(0).String()
-				default:
-					ts = cm.At(0).String()
-					convertToArgs = cm.Slice(1, cm.Len()).AppendTo(make([]px.Value, 0, cm.Len()-1))
-				}
 			} else {
-				ts = ct.String()
+				merge, ok = lo[`merge`]
+				if !ok {
+					merge = first
+				} else {
+					ic.ReportMergeSource(`"lookup_options" hash`)
+				}
 			}
 		}
-		if ts != `` {
-			convertToType = ic.ParseType(ts)
-			redacted = ts == `Sensitive`
+
+		var mh px.OrderedMap
+		var mergeOpts map[string]px.Value
+		if mh, ok = merge.(px.OrderedMap); ok {
+			merge = mh.Get5(`strategy`, first)
+			mergeOpts = make(map[string]px.Value, mh.Len())
+			mh.EachPair(func(k, v px.Value) {
+				ks := k.String()
+				if ks != `strategy` {
+					mergeOpts[ks] = v
+				}
+			})
 		}
-	}
 
-	var v px.Value
-	hf := func() {
-		ms := hieraapi.GetMergeStrategy(merge.String(), mergeOpts)
-		v = ms.Lookup(cfg.Hierarchy(), ic, func(prv interface{}) px.Value {
-			pr := prv.(hieraapi.DataProvider)
-			return pr.UncheckedLookup(k, ic, ms)
-		})
-	}
+		redacted := false
 
-	if redacted {
-		ic.DoRedacted(hf)
-	} else {
-		hf()
-	}
-
-	if v != nil && convertToType != nil {
-		av := []px.Value{v}
-		if convertToArgs != nil {
-			av = append(av, convertToArgs...)
+		var convertToType px.Type
+		var convertToArgs []px.Value
+		if lo != nil {
+			ts := ``
+			if ct, ok := lo[`convert_to`]; ok {
+				if cm, ok := ct.(*types.Array); ok {
+					// First arg must be a type. The rest is arguments
+					switch cm.Len() {
+					case 0:
+						// Obviously bogus
+					case 1:
+						ts = cm.At(0).String()
+					default:
+						ts = cm.At(0).String()
+						convertToArgs = cm.Slice(1, cm.Len()).AppendTo(make([]px.Value, 0, cm.Len()-1))
+					}
+				} else {
+					ts = ct.String()
+				}
+			}
+			if ts != `` {
+				convertToType = ic.ParseType(ts)
+				redacted = ts == `Sensitive`
+			}
 		}
-		v = px.New(ic, convertToType, av...)
-	}
-	return v
+
+		var v px.Value
+		hf := func() {
+			ms := hieraapi.GetMergeStrategy(merge.String(), mergeOpts)
+			v = ms.Lookup(cfg.Hierarchy(), ic, func(prv interface{}) px.Value {
+				pr := prv.(hieraapi.DataProvider)
+				return pr.UncheckedLookup(k, ic, ms)
+			})
+		}
+
+		if redacted {
+			ic.DoRedacted(hf)
+		} else {
+			hf()
+		}
+
+		if v != nil && convertToType != nil {
+			av := []px.Value{v}
+			if convertToArgs != nil {
+				av = append(av, convertToArgs...)
+			}
+			v = px.New(ic, convertToType, av...)
+		}
+		return v
+	})
 }


### PR DESCRIPTION
This commit adds the two CLI options --explain and --explain-options.
Using them results in the same output as when used by the puppet
lookup command.