### PR TITLE
Ensure that hierarchy options are passed on to provider function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ require (
 	github.com/bmatcuk/doublestar v1.1.1
 	github.com/hashicorp/go-hclog v0.9.0
 	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
-	github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad
+	github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
 github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad h1:Smdt4D4MrveCvMVgQVQ7JAvMiY0+q5p/Nc/PKtQUv+E=
 github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307 h1:Dr/NfFG/2mEgleyfsiLT+9j7olm5imQkynsDRpGL8Tk=
+github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/hieraapi/api.go
+++ b/hieraapi/api.go
@@ -40,6 +40,7 @@ type Function interface {
 type Entry interface {
 	Copy(Config) Entry
 	Options() px.OrderedMap
+	OptionsMap() map[string]px.Value
 	DataDir() string
 	Function() Function
 	Name() string

--- a/internal/config.go
+++ b/internal/config.go
@@ -39,6 +39,7 @@ type entry struct {
 	cfg       *hieraCfg
 	dataDir   string
 	options   px.OrderedMap
+	optsMap   map[string]px.Value
 	function  hieraapi.Function
 	name      string
 	locations []hieraapi.Location
@@ -46,6 +47,10 @@ type entry struct {
 
 func (e *entry) Options() px.OrderedMap {
 	return e.options
+}
+
+func (e *entry) OptionsMap() map[string]px.Value {
+	return e.optsMap
 }
 
 func (e *entry) DataDir() string {
@@ -133,11 +138,13 @@ func (e *entry) Resolve(ic hieraapi.Invocation, defaults hieraapi.Entry) hieraap
 	if ce.options == nil {
 		if defaults != nil {
 			ce.options = defaults.Options()
+			ce.optsMap = defaults.OptionsMap()
 		}
 	} else if ce.options.Len() > 0 {
 		if o, oc := doInterpolate(ic, ce.options, false); oc {
 			ce.options = o.(*types.Hash)
 		}
+		ce.optsMap = ce.options.ToStringMap()
 	}
 
 	var dataRoot string

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -5,6 +5,9 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lyraproj/hiera/hieraapi"
+	"github.com/lyraproj/pcore/px"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -199,6 +202,36 @@ Searching for "hash"
         \}
       \}
 \z`, string(result))
+	})
+}
+
+func customLK(hc hieraapi.ProviderContext, key string, options map[string]px.Value) px.Value {
+	if v, ok := options[key]; ok {
+		return v
+	}
+	hc.NotFound()
+	return nil // Not reached
+}
+
+func init() {
+	px.NewGoFunction(`customLK`,
+		func(d px.Dispatch) {
+			d.Param(`Hiera::Context`)
+			d.Param(`String`)
+			d.Param(`Hash[String,Any]`)
+			d.Function(func(c px.Context, args []px.Value) px.Value {
+				return customLK(args[0].(hieraapi.ProviderContext), args[1].String(), args[2].(px.OrderedMap).ToStringMap())
+			})
+		},
+	)
+}
+
+func TestLookup_withCustomLK(t *testing.T) {
+
+	inTestdata(func() {
+		result, err := executeLookup(`--config`, `with_custom_provider.yaml`, `a`)
+		require.NoError(t, err)
+		require.Equal(t, "option a\n", string(result))
 	})
 }
 

--- a/lookup/testdata/with_custom_provider.yaml
+++ b/lookup/testdata/with_custom_provider.yaml
@@ -1,0 +1,8 @@
+version: 5
+
+hierarchy:
+  - name: Custom
+    lookup_key: customLK
+    options:
+      a: option a
+      b: option b


### PR DESCRIPTION
This commit changes how providers are constituted so that they now
contain the actual hierarchy entry. The options from the entry is then
passed on, possibly augmented with a "path" entry, in calls to the
actual provider function.

A small sample of how to add a provider function dynamically is included
in the lookup/lookup_test.go file.

Closes #25