### PR TITLE
Improve passing of variables using CLI options

### DIFF
--- a/hieraserver/rest.go
+++ b/hieraserver/rest.go
@@ -48,7 +48,8 @@ func newCommand() *cobra.Command {
 	flags := cmd.Flags()
 	flags.StringVar(&logLevel, `loglevel`, `error`, `error/warn/info/debug`)
 	flags.StringVar(&config, `config`, ``, `path to the hiera config file. Overrides <current directory>/hiera.yaml`)
-	flags.StringVar(&cmdOpts.Variables, `variables`, ``, `path to a JSON or YAML file that contains key-value mappings to become scope variables`)
+	flags.StringArrayVar(&cmdOpts.VarPaths, `vars`, nil, `path to a JSON or YAML file that contains key-value mappings to become variables for this lookup`)
+	flags.StringArrayVar(&cmdOpts.Variables, `var`, nil, `variable as a key:value or key=value where value is a literal expressed in Puppet DSL`)
 	flags.IntVar(&port, `port`, 80, `port number to listen to`)
 	return cmd
 }

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -75,6 +75,22 @@ func TestLookup_fact_interpolated_config(t *testing.T) {
 	})
 }
 
+func TestLookup_vars_interpolated_config(t *testing.T) {
+	inTestdata(func() {
+		result, err := executeLookup(`--vars`, `facts.yaml`, `interpolate_ca`)
+		require.NoError(t, err)
+		require.Equal(t, "This is value of c.a\n", string(result))
+	})
+}
+
+func TestLookup_var_interpolated_config(t *testing.T) {
+	inTestdata(func() {
+		result, err := executeLookup(`--var`, `c={a=>'the option value'}`, `--var`, `data_file: by_fact`, `interpolate_ca`)
+		require.NoError(t, err)
+		require.Equal(t, "This is the option value\n", string(result))
+	})
+}
+
 func TestLookup_fact_directly(t *testing.T) {
 	inTestdata(func() {
 		result, err := executeLookup(`--facts`, `facts.yaml`, `--config`, `fact_directly.yaml`, `the_fact`)


### PR DESCRIPTION
This commit provides the following improvements of how variables can be
set in the Hiera scope by using command line options:

--vars, a repeatable option that appoints yaml or json files on disk, or
  if the option argument is a single '-' (dash) then the yaml or json is
  parsed from stdin.

--var, a repeatable option to provide variables directly on the command
  line using key=value or key:value syntax. The value is expressed using
  Puppet DSL.

--facts, an alias for --vars, is retained for compatibility with the
  Puppet ruby version of Hiera.

Closes #20