### PR TITLE
Container and httpserver improvements, doc updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,11 @@ RUN go install ./...
 # copy the executable over
 FROM alpine
 COPY --from=build_base /go/bin/hieraserver /bin/hieraserver
-CMD ["/bin/hieraserver", "--port", "8080"]
+RUN mkdir /hiera
+
+# Configurable values for runtime overrides
+ENV port 8080
+ENV loglevel error
+ENV config /hiera/hiera.yaml
+
+CMD /bin/hieraserver --port ${port} --loglevel ${loglevel} --config ${config}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ Hiera is a flexible, powerful tool for resolving values for variable lookups, wh
 
 This module is a "clean-room" Go implementation of the Hiera framework, suitable for use as a library from other tools.
 
-## How to use
+## Details
+
+Hiera uses the concept of "managing by exception": you design a *hierarchy* of data sources, with the most specific source at the top and  least-specific defaults at the bottom. Hiera searches for keys starting at the top, allowing more-specific sources to override defaults. Sources are usually YAML files stored on the filesystem, and layers usually use variable interpolation to find the right file, allowing the context of the lookup to pick the right file.
+
+## How to run it
+
+### Standalone execution
 
 Hiera is a go module and go modules must be enabled by setting the environment variable GO111MODULE is on before an
 attempt is made to install:
@@ -29,9 +35,83 @@ Install the lookup binary under $GOPATH/bin:
 
     lookup --help
 
-## Details
+### Containerized execution
 
-Hiera uses the concept of "managing by exception": you design a *hierarchy* of data sources, with the most specific source at the top and  least-specific defaults at the bottom. Hiera searches for keys starting at the top, allowing more-specific sources to override defaults. Sources are usually YAML files stored on the filesystem, and layers usually use variable interpolation to find the right file, allowing the context of the lookup to pick the right file.
+#### Download the container
+
+You can pull the latest containerized version from docker hub:
+
+    docker pull lyraproj/hiera:latest
+
+The docker repository with previous tags is viewable at https://hub.docker.com/r/lyraproj/hiera .
+
+#### Run the container
+
+The docker image accepts environment variables to override default behaviour:
+    *port* - which port to listen on inside the container (default: 8080)
+    *loglevel* - how much logging to do (default: error, possible values: error, warn, info, debug)
+    *config* - path to a hiera.yaml configuration (default: /hiera/hiera.yaml)
+
+Make sure to pass the port on your host through to the container. A directory with a hiera configuration and data files (see below) should be mounted under `/hiera` in the image using a bind mount:
+
+    docker run -p 8080:8080 --mount type=bind,src=$HOME/hiera,dst=/hiera lyraproj/hiera:latest
+
+#### Query the container
+
+The web service in the container responds to the `/lookup` endpoint with an additional path element of which key to look up. Nested keys can be looked up using dot-separation notation. Given a yaml map without any overrides like:
+
+    aws:
+      tags:
+        Name:       lyra-sample
+        created_by: lyra
+        department: engineering
+        project:    incubator
+        lifetime:   1h
+
+You can get back the entire map or specific parts of it:
+
+    $ curl http://localhost:8080/lookup/aws
+    {"tags":{"Name":"lyra-sample","created_by":"lyra","department":"engineering","lifetime":"1h","project":"incubator"}}
+    $ curl http://localhost:8080/lookup/aws.tags
+    {"Name":"lyra-sample","created_by":"lyra","department":"engineering","lifetime":"1h","project":"incubator"}
+    $ curl http://localhost:8080/lookup/aws.tags.department
+    "engineering"
+
+## Pass values for interpolation
+
+If your hierarchy config contains variable interpolation, you can provide context for the lookup using the `var` query parameter. Repeated `var` parameters will create an array of available parameters. The values should be colon-separated variable-value pairs:
+
+    curl 'http://localhost:8080/lookup/aws.tags?var=environment:production&var=hostname:specialhost'
+
+TODO: Nested variable lookups such like `os.family` are not yet working.
+
+## Hiera configuration and directory structure
+
+Much of hiera's power lies in its ability to interpolate variables in the hierarchy's configuration. A lookup provides values, and hiera maps the interpolated values onto the filesystem (or other back-end data structure). A common example uses two levels of override: one for specific hosts, a higher layer for environment-wide settings, and finally a fall-through default. A functional `hiera.yaml` which implements this policy looks like:
+
+    ---
+    version: 5
+    defaults:
+    datadir: hiera
+    data_hash: yaml_data
+
+    hierarchy:
+    - name: "Host-specific overrides"
+        path: "hosts/%{hostname}.yaml"
+    - name: "Environmental overrides"
+        path: "environments/%{environment}.yaml"
+    - name: "Fall through defaults"
+        path: "defaults.yaml"
+
+This maps to a directory structure based in the `hiera` subdirectory (due to the `datadir` top level key) containing yaml files like:
+
+    hiera
+    ├── defaults.yaml
+    ├── environments
+    │   └── production.yaml
+    └── hosts
+        └── specialhost.yaml
+
 
 ## Implementation status
 
@@ -49,4 +129,5 @@ Hiera uses the concept of "managing by exception": you design a *hierarchy* of d
 * [x] Sensitive data
 * [ ] configurable deep merge
 * [ ] pluggable back ends (initially for secrets management)
-* [ ] `explain` functionality to show traversal
+* [x] `explain` functionality to show traversal
+* [x] containerized REST-based microservice


### PR DESCRIPTION
This adds the ability to pass variables into the http query
using '?var=varname:value' query parameters.

The container build now creates a top level directory /hiera
which is suitable for bind-mounting a sidecar or data directory
from the host.

The documentation is updated with the behaviour of the rest server.