### PR TITLE
Drop caching of resolved configuration and previous lookups

### DIFF
--- a/hieraapi/dataprovider.go
+++ b/hieraapi/dataprovider.go
@@ -3,6 +3,9 @@ package hieraapi
 import "github.com/lyraproj/pcore/px"
 
 type DataProvider interface {
-	UncheckedLookup(key Key, invocation Invocation, merge MergeStrategy) px.Value
+	// Lookup performs an lookup using this data provider
+	Lookup(key Key, invocation Invocation, merge MergeStrategy) px.Value
+
+	// FullName returns a descriptive name of the data provider. Used by the explainer
 	FullName() string
 }

--- a/hieraapi/providercontext_test.go
+++ b/hieraapi/providercontext_test.go
@@ -18,7 +18,7 @@ func ExampleProviderContext_CachedValue() {
 			return v
 		}
 		fmt.Printf("Creating and caching value for %s\n", key)
-		v := ic.Interpolate(types.WrapString(fmt.Sprintf("generated value for %%{%s}", key)))
+		v := ic.Interpolate(types.WrapString(fmt.Sprintf("value for %%{%s}", key)))
 		ic.Cache(key, v)
 		return v
 	}
@@ -36,9 +36,11 @@ func ExampleProviderContext_CachedValue() {
 	})
 	// Output:
 	// Creating and caching value for a
-	// generated value for scope 'a'
+	// value for scope 'a'
 	// Creating and caching value for b
-	// generated value for scope 'b'
-	// generated value for scope 'a'
-	// generated value for scope 'b'
+	// value for scope 'b'
+	// Returning cached value for a
+	// value for scope 'a'
+	// Returning cached value for b
+	// value for scope 'b'
 }

--- a/internal/config.go
+++ b/internal/config.go
@@ -238,7 +238,7 @@ func (hc *hieraCfg) Resolve(ic hieraapi.Invocation) (cfg hieraapi.ResolvedConfig
 	v := ic.WithLookup(k, func() px.Value {
 		return ms.Lookup(r.Hierarchy(), ic, func(prv interface{}) px.Value {
 			pr := prv.(hieraapi.DataProvider)
-			return pr.UncheckedLookup(k, ic, ms)
+			return pr.Lookup(k, ic, ms)
 		})
 	})
 

--- a/internal/datadigprovider.go
+++ b/internal/datadigprovider.go
@@ -14,7 +14,7 @@ type DataDigProvider struct {
 	hashes         *sync.Map
 }
 
-func (dh *DataDigProvider) UncheckedLookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
+func (dh *DataDigProvider) Lookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
 	return invocation.WithDataProvider(dh, func() px.Value {
 		locations := dh.hierarchyEntry.Locations()
 		switch len(locations) {

--- a/internal/datahashprovider.go
+++ b/internal/datahashprovider.go
@@ -18,7 +18,7 @@ type DataHashProvider struct {
 	hashesLock     sync.RWMutex
 }
 
-func (dh *DataHashProvider) UncheckedLookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
+func (dh *DataHashProvider) Lookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
 	return invocation.WithDataProvider(dh, func() px.Value {
 		locations := dh.hierarchyEntry.Locations()
 		switch len(locations) {

--- a/internal/init.go
+++ b/internal/init.go
@@ -83,7 +83,7 @@ func Lookup2(
 		if ov, ok := override.Get4(name); ok {
 			return ov
 		}
-		v := ic.(*invocation).lookupViaCache(newKey(name), options)
+		v := ic.(*invocation).lookup(newKey(name), options)
 		if v != nil {
 			return v
 		}

--- a/internal/lookupkeyprovider.go
+++ b/internal/lookupkeyprovider.go
@@ -17,7 +17,7 @@ type LookupKeyProvider struct {
 	hashes         *sync.Map
 }
 
-func (dh *LookupKeyProvider) UncheckedLookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
+func (dh *LookupKeyProvider) Lookup(key hieraapi.Key, invocation hieraapi.Invocation, merge hieraapi.MergeStrategy) px.Value {
 	return invocation.WithDataProvider(dh, func() px.Value {
 		locations := dh.hierarchyEntry.Locations()
 		switch len(locations) {

--- a/provider/configlookupkey.go
+++ b/provider/configlookupkey.go
@@ -81,7 +81,7 @@ func ConfigLookupKey(pc hieraapi.ProviderContext, key string, options map[string
 			ms := hieraapi.GetMergeStrategy(hieraapi.MergeStrategyName(merge.String()), mergeOpts)
 			v = ms.Lookup(cfg.Hierarchy(), ic, func(prv interface{}) px.Value {
 				pr := prv.(hieraapi.DataProvider)
-				return pr.UncheckedLookup(k, ic, ms)
+				return pr.Lookup(k, ic, ms)
 			})
 		}
 


### PR DESCRIPTION
This commit ensures that the hiera configuration is resolved on each
invocation and that no values are cached between invocations.

A side effect of this is that the cache provided in the ProviderContext
now has the same short life cycle as the invocation.