### PR TITLE
Enable rendering of explanation output

### DIFF
--- a/explain/explainer.go
+++ b/explain/explainer.go
@@ -1,15 +1,15 @@
 package explain
 
 import (
-	"github.com/lyraproj/pcore/utils"
-
 	"github.com/lyraproj/hiera/hieraapi"
 	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/pcore/utils"
 )
 
 type Context int
 
 type Explainer interface {
+	px.Value
 	utils.Indentable
 
 	// AcceptFound accepts information that a value was found for a given key

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.2.9 // indirect
 	github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15
-	github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307
+	github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,12 @@ github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad h1:Smdt4D4MrveCvMVg
 github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307 h1:Dr/NfFG/2mEgleyfsiLT+9j7olm5imQkynsDRpGL8Tk=
 github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58 h1:KVwA8JT513CGkM6SVLxGIfqeLUgW3p+dDq1UEC7lYG8=
+github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190716091017-ba8ad962370f h1:vHGIY4Wj2Sf3V1z2JtafmU45Ook/eoJdTWKxyWkgtXU=
+github.com/lyraproj/pcore v0.0.0-20190716091017-ba8ad962370f/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
+github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850 h1:AcpbJKP33rWGYEtKeCZIaEDDcVT8sDVDU6NUsQxT738=
+github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2/go.mod h1:KOdZKnEBdDb2iGPUnHiKpk3M5cvv949xMyj8XPqaMF0=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/hiera/hiera.go
+++ b/hiera/hiera.go
@@ -16,7 +16,6 @@ import (
 	"github.com/lyraproj/pcore/pcore"
 	"github.com/lyraproj/pcore/px"
 	"github.com/lyraproj/pcore/types"
-	"github.com/lyraproj/pcore/utils"
 	"github.com/lyraproj/pcore/yaml"
 )
 
@@ -149,21 +148,16 @@ func LookupAndRender(c px.Context, opts *CommandOptions, args []string, out io.W
 
 	var explainer explain.Explainer
 	if opts.ExplainData || opts.ExplainOptions {
-		if opts.RenderAs != `` {
-			var ex string
-			if opts.ExplainData {
-				ex = `explain`
-			} else {
-				ex = `explain-options`
-			}
-			panic(fmt.Errorf(`--render-as is mutually exclusive to --%s`, ex))
-		}
 		explainer = explain.NewExplainer(opts.ExplainOptions, opts.ExplainOptions && !opts.ExplainData)
 	}
 
 	found := Lookup2(internal.NewInvocation(c, scope, explainer), args, tp, dv, nil, nil, options, nil)
 	if explainer != nil {
-		utils.Fprintln(out, explainer)
+		renderAs := Text
+		if opts.RenderAs != `` {
+			renderAs = RenderName(opts.RenderAs)
+		}
+		Render(c, renderAs, explainer, out)
 		return found != nil
 	}
 

--- a/hieraapi/location.go
+++ b/hieraapi/location.go
@@ -12,7 +12,7 @@ const LcMappedPaths = LocationKind(`mapped_paths`)
 type Location interface {
 	fmt.Stringer
 	Kind() LocationKind
-	Exist() bool
+	Exists() bool
 	Resolve(ic Invocation, dataDir string) []Location
 	Original() string
 	Resolved() string

--- a/hieraapi/mergestrategy.go
+++ b/hieraapi/mergestrategy.go
@@ -22,6 +22,8 @@ var GetMergeStrategy func(name MergeStrategyName, options map[string]px.Value) M
 type MergeStrategy interface {
 	issue.Labeled
 
+	Name() MergeStrategyName
+
 	// Lookup performs a series of lookups for each variant found in the given variants slice. The actual
 	// lookup value is returned by the given value function which will be called at least once. The argument to
 	// the value function will be an element of the variants slice.

--- a/internal/datadigprovider.go
+++ b/internal/datadigprovider.go
@@ -35,7 +35,7 @@ func (dh *DataDigProvider) invokeWithLocation(invocation hieraapi.Invocation, lo
 		return dh.lookupKey(invocation, nil, key)
 	}
 	result := invocation.WithLocation(location, func() px.Value {
-		if location.Exist() {
+		if location.Exists() {
 			return dh.lookupKey(invocation, location, key)
 		}
 		invocation.ReportLocationNotFound()

--- a/internal/datahashprovider.go
+++ b/internal/datahashprovider.go
@@ -39,7 +39,7 @@ func (dh *DataHashProvider) invokeWithLocation(invocation hieraapi.Invocation, l
 		return dh.lookupKey(invocation, nil, root)
 	}
 	return invocation.WithLocation(location, func() px.Value {
-		if location.Exist() {
+		if location.Exists() {
 			return dh.lookupKey(invocation, location, root)
 		}
 		invocation.ReportLocationNotFound()

--- a/internal/lookupkeyprovider.go
+++ b/internal/lookupkeyprovider.go
@@ -38,7 +38,7 @@ func (dh *LookupKeyProvider) invokeWithLocation(invocation hieraapi.Invocation, 
 		return dh.lookupKey(invocation, nil, root)
 	}
 	return invocation.WithLocation(location, func() px.Value {
-		if location.Exist() {
+		if location.Exists() {
 			return dh.lookupKey(invocation, location, root)
 		}
 		invocation.ReportLocationNotFound()

--- a/internal/mergestrategy.go
+++ b/internal/mergestrategy.go
@@ -87,6 +87,10 @@ func variantLookup(v reflect.Value, vf func(l interface{}) px.Value) px.Value {
 	return nil
 }
 
+func (d *firstFound) Name() hieraapi.MergeStrategyName {
+	return hieraapi.First
+}
+
 func (d *firstFound) Label() string {
 	return `first found strategy`
 }
@@ -135,6 +139,10 @@ func (d *firstFound) merge(a, b px.Value) px.Value {
 	return a
 }
 
+func (d *unique) Name() hieraapi.MergeStrategyName {
+	return hieraapi.Unique
+}
+
 func (d *unique) Label() string {
 	return `unique merge strategy`
 }
@@ -166,6 +174,10 @@ func (d *unique) merge(a, b px.Value) px.Value {
 	return d.convertValue(a).(px.List).AddAll(d.convertValue(b).(px.List)).Unique()
 }
 
+func (d *deepMerge) Name() hieraapi.MergeStrategyName {
+	return hieraapi.Deep
+}
+
 func (d *deepMerge) Label() string {
 	return `deep merge strategy`
 }
@@ -192,6 +204,10 @@ func (d *deepMerge) convertValue(v px.Value) px.Value {
 func (d *deepMerge) merge(a, b px.Value) px.Value {
 	v, _ := DeepMerge(a, b, d.opts)
 	return v
+}
+
+func (d *hashMerge) Name() hieraapi.MergeStrategyName {
+	return hieraapi.Hash
 }
 
 func (d *hashMerge) Label() string {

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -143,7 +143,7 @@ branches:
                     __ptype: Hiera::Path
                     exists: true
                     original: common\.yaml
-                    resolved: /home/thhal/go/src/github.com/lyraproj/hiera/lookup/testdata/hiera/common\.yaml
+                    resolved: .*/testdata/hiera/common\.yaml
             providerName: data_hash function 'yaml_data'
           - __ptype: Hiera::ExplainProvider
             branches:
@@ -166,7 +166,7 @@ branches:
                     __ptype: Hiera::Path
                     exists: true
                     original: named_%\{data_file\}\.yaml
-                    resolved: /home/thhal/go/src/github.com/lyraproj/hiera/lookup/testdata/hiera/named_by_fact\.yaml
+                    resolved: .*/testdata/hiera/named_by_fact\.yaml
                 value: This is value of c\.a
             providerName: data_hash function 'yaml_data'
         event: 6


### PR DESCRIPTION
This commit turns the node objects used by the explainer into pcore
objects so that they can be serialized properly. The serialization is
then used when a combination of --explain and --render-as is given on
the command line. This enables explanation output to be rendered as
JSON or YAML which in turn is a first step towards a distributed Hiera
with full explanation support.