### PR TITLE
Add json-schema for the hiera.yaml configuration

### DIFF
--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JsonSchemaMappingsProjectConfiguration">
+    <state>
+      <map>
+        <entry key="Hiera Configuration">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="Hiera Configuration" />
+              <option name="relativePathToSchema" value="schema/hiera_v5.yaml" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="pattern" value="true" />
+                    <option name="path" value="hiera.yaml" />
+                    <option name="mappingKind" value="Pattern" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
+      </map>
+    </state>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -132,3 +132,4 @@ This maps to a directory structure based in the `hiera` subdirectory (due to the
 * [ ] pluggable back ends (initially for secrets management)
 * [x] `explain` functionality to show traversal
 * [x] containerized REST-based microservice
+* [x] JSON and YAML schema for the hiera.yaml config file (see schema/hiera_v5.yaml)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,5 @@ require (
 	github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850
 	github.com/spf13/cobra v0.0.4
 	github.com/stretchr/testify v1.3.0
-	gopkg.in/yaml.v2 v2.2.2
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/go.sum
+++ b/go.sum
@@ -25,14 +25,6 @@ github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b h1:qGgMkFUQ
 github.com/lyraproj/data-protobuf v0.0.0-20190329160005-a909d9e1f93b/go.mod h1:oQIFBu0fmkiSpSRROEgK5gnjQ/ZDrx3UdpRpT3791Gg=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15 h1:e1uefKgfSdC7uaYG9ipIZcpY+2gyefCYXQwsrWSdJLw=
 github.com/lyraproj/issue v0.0.0-20190606092846-e082d6813d15/go.mod h1:jqRRmAiVqjTehhncbKJPoC2AFoxxkritzzlfWioTa00=
-github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad h1:Smdt4D4MrveCvMVgQVQ7JAvMiY0+q5p/Nc/PKtQUv+E=
-github.com/lyraproj/pcore v0.0.0-20190619162937-645af37a80ad/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
-github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307 h1:Dr/NfFG/2mEgleyfsiLT+9j7olm5imQkynsDRpGL8Tk=
-github.com/lyraproj/pcore v0.0.0-20190709110110-57c90466e307/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
-github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58 h1:KVwA8JT513CGkM6SVLxGIfqeLUgW3p+dDq1UEC7lYG8=
-github.com/lyraproj/pcore v0.0.0-20190716055636-c093587ebc58/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
-github.com/lyraproj/pcore v0.0.0-20190716091017-ba8ad962370f h1:vHGIY4Wj2Sf3V1z2JtafmU45Ook/eoJdTWKxyWkgtXU=
-github.com/lyraproj/pcore v0.0.0-20190716091017-ba8ad962370f/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850 h1:AcpbJKP33rWGYEtKeCZIaEDDcVT8sDVDU6NUsQxT738=
 github.com/lyraproj/pcore v0.0.0-20190716112816-4f6c9937c850/go.mod h1:yqZNNXXw/2It5Jh2Vc+g93Qm+1q6EklXJ0t/xqNNBV8=
 github.com/lyraproj/semver v0.0.0-20181213164306-02ecea2cd6a2 h1:vb4PbiMtIXdhsOUinkkcqZiASDIZzXRhSG4yvNfE0tg=

--- a/schema/.gitignore
+++ b/schema/.gitignore
@@ -1,0 +1,1 @@
+hiera_v5.json

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,7 @@
+## Schema for the hiera.yaml config
+
+This directory contains the [json schema](https://json-schema.org/) for the hiera.yaml configuration. The schema is maintained
+in yaml and the json version is generated from this directory like so:
+```bash
+go run ../yaml2json < hiera_v5.yaml > hiera_v5.json
+```

--- a/schema/hiera_v5.yaml
+++ b/schema/hiera_v5.yaml
@@ -1,0 +1,164 @@
+---
+title: JSON schema for Hiera configuration
+"$schema": http://json-schema.org/draft-04/schema#
+type: object
+definitions:
+  defaultsBase:
+    description: Default values for the lookup function, datadir, and option keys, when those keys are omitted in the hierarchy levels.
+    type: object
+    properties:
+      datadir:
+        description: Default value for datadir, used for any file-based hierarchy level that doesn't specify its own.
+        type: string
+      options:
+        description: Default value for options, used for any hierarchy level that does not specify its own.
+        type: object
+      data_dig:
+        description: Default name of function that produces values key by key and digs into dotted key notations.
+        type: string
+      data_hash:
+        description: Default name of function that produces a hash of key-value pairs.
+        type: string
+      lookup_key:
+        description: Default name of function that produces values key by key.
+        type: string
+    additionalProperties: false
+  levelBase:
+    description: Hierarchy level.
+    type: object
+    properties:
+      name:
+        description: A name for this level, shown to humans in debug messages and --explain output.
+        type: string
+      datadir:
+        description: The directory where data files are kept; can be omitted if you set a default
+        type: string
+      options:
+        description: Options to pass on to the data provider function
+        type: object
+      path:
+        description: Path to the data file, relative to datadir.
+        type: string
+      paths:
+        description: Paths to data files, relative to datadir.
+        type: array
+        items:
+          type: string
+      glob:
+        description: Glob that expands to paths to data files, relative to datadir.
+        type: string
+      globs:
+        description: Globs that expand to paths to data files, relative to datadir.
+        type: array
+        items:
+          type: string
+      uri:
+        description: URI that appoints data or a lookup service.
+        type: string
+      uris:
+        description: URIs that appoint data or a lookup services.
+        type: array
+        items:
+          type: string
+      mapped_paths:
+        description: Array with exactly three string elements describing how to create
+          paths from the elements of a collection.
+        type: array
+        items:
+          - description: Name of a collection variable.
+            type: string
+          - description: Name of a variable to use in interpolation.
+            type: string
+          - description: Interpolation expression containing the named variable.
+            type: string
+        minItems: 3
+        maxItems: 3
+      data_dig:
+        description: Name of function that produces values key by key and digs into dotted key notations.
+        type: string
+      data_hash:
+        description: Name of function that produces a hash of key-value pairs.
+        type: string
+      lookup_key:
+        description: Name of function that produces values key by key.
+        type: string
+    additionalProperties: false
+    required:
+      - name
+  location:
+    oneOf:
+      - required:
+          - path
+      - required:
+          - paths
+      - required:
+          - glob
+      - required:
+          - globs
+      - required:
+          - uri
+      - required:
+          - uris
+      - required:
+          - mappded_paths
+      - not:
+          anyOf:
+            - required:
+                - path
+            - required:
+                - paths
+            - required:
+                - glob
+            - required:
+                - globs
+            - required:
+                - uri
+            - required:
+                - uris
+            - required:
+                - mappded_paths
+  providerFunction:
+    oneOf:
+      - not:
+          anyOf:
+            - required:
+                - data_dig
+            - required:
+                - data_hash
+            - required:
+                - lookup_key
+      - required:
+          - data_dig
+      - required:
+          - data_hash
+      - required:
+          - lookup_key
+  defaults:
+    allOf:
+      - "$ref": "#/definitions/defaultsBase"
+      - "$ref": "#/definitions/providerFunction"
+  level:
+    allOf:
+      - "$ref": "#/definitions/levelBase"
+      - "$ref": "#/definitions/location"
+      - "$ref": "#/definitions/providerFunction"
+  hierarchy:
+    description: An array of hashes, where each hash configures one level of the hierarchy.
+    type: array
+    items:
+      "$ref": "#/definitions/level"
+properties:
+  version:
+    description: Required, must be the number 5, without quotes
+    type: integer
+    minimum: 5
+    maximum: 5
+  defaults:
+    "$ref": "#/definitions/defaults"
+  hierarchy:
+    "$ref": "#/definitions/hierarchy"
+  default_hierarchy:
+    "$ref": "#/definitions/hierarchy"
+required:
+  - version
+additionalProperties: false

--- a/yaml2json/main.go
+++ b/yaml2json/main.go
@@ -1,0 +1,43 @@
+// Utility program to convert yaml on stdin to formatted json on stdout
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+func stringKeys(x interface{}) interface{} {
+	switch x := x.(type) {
+	case map[interface{}]interface{}:
+		m := map[string]interface{}{}
+		for k, v := range x {
+			m[k.(string)] = stringKeys(v)
+		}
+		return m
+	case []interface{}:
+		for i, v := range x {
+			x[i] = stringKeys(v)
+		}
+	}
+	return x
+}
+
+func main() {
+	data, err := ioutil.ReadAll(os.Stdin)
+	if err == nil {
+		var body interface{}
+		if err = yaml.Unmarshal(data, &body); err == nil {
+			var bytes []byte
+			if bytes, err = json.MarshalIndent(stringKeys(body), ``, ` `); err == nil {
+				if _, err = os.Stdout.Write(bytes); err == nil {
+					return
+				}
+			}
+		}
+	}
+	log.Fatal(err.Error())
+}


### PR DESCRIPTION
This commit adds a json-schema (in yaml format) for the hiera version 5
configuration along with a small utility program that converts the yaml
schema into pretty printed json.