### PR TITLE
Add docker build workflow 

### DIFF
--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -13,7 +13,6 @@ jobs:
     - name: Build and publish
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-	name: lyraproj/hiera
-	username: {{ secrets.DOCKER_USERNAME }}
-	password: {{ secrets.DOCKER_PASSWORD }}
-
+        name: lyraproj/hiera
+        username: {{ secrets.DOCKER_USERNAME }}
+        password: {{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -1,0 +1,19 @@
+name: Docker Image Build + Push
+
+on: [push]
+
+jobs:
+
+  build:
+ 
+    runs-on: ubuntu-latest
+ 
+    steps:
+    - uses: actions/checkout@master
+    - name: Build and publish
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+	name: lyraproj/hiera
+	username: {{ secrets.DOCKER_USERNAME }}
+	password: {{ secrets.DOCKER_PASSWORD }}
+

--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -9,10 +9,11 @@ jobs:
     runs-on: ubuntu-latest
  
     steps:
-    - uses: actions/checkout@master
+    - name: Check out repo
+      uses: actions/checkout@master
     - name: Build and publish
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: lyraproj/hiera
-        username: {{ secrets.DOCKER_USERNAME }}
-        password: {{ secrets.DOCKER_PASSWORD }}
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go install ./...
 # Ensure that a plugin directory is present
 RUN mkdir -p plugin
 
-# Include externa plugins. A prerequisite is that the plugin source is copied into the hiera/plugin directory
+# Include external plugins. A prerequisite is that the plugin source is copied into the hiera/plugin directory
 # prior to the docker build.
 
 # Add plugin builds here...
@@ -26,7 +26,7 @@ RUN mkdir -p plugin
 # Create a new minimalisic image that doesn't contain the build environment and
 # copy the executable over
 FROM alpine
-COPY --from=build_base /go/bin/hieraserver /bin/hieraserver
+COPY --from=build_base /go/bin/rest /bin/hieraserver
 RUN mkdir -p /hiera/plugin
 COPY --from=build_base /go/src/github.com/lyraproj/hiera/plugin/* /hiera/plugin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p plugin
 FROM alpine
 COPY --from=build_base /go/bin/rest /bin/hieraserver
 RUN mkdir -p /hiera/plugin
-COPY --from=build_base /go/src/github.com/lyraproj/hiera/plugin/* /hiera/plugin/
+# COPY --from=build_base /go/src/github.com/lyraproj/hiera/plugin/* /hiera/plugin/
 
 # Configurable values for runtime overrides
 ENV port 8080


### PR DESCRIPTION
This adds a (now working!) Docker image build and push github action.

It pushes to https://hub.docker.com/r/lyraproj/hiera , with an image tagged
the same name as the branch (or git tag) that was pushed.

(This commit series probably needs a squash-and-merge as there are several trivial commits)

Closes #41 