### PR TITLE
Handle special case of rendring an empty map in JSON

### DIFF
--- a/hiera/render.go
+++ b/hiera/render.go
@@ -43,6 +43,10 @@ func Render(c px.Context, renderAs RenderName, value px.Value, out io.Writer) {
 		if renderAs == `yaml` {
 			bs, err = yaml.Marshal(v)
 		} else {
+			// JSON is not able to handle the result of reflecting an empty untyped map.
+			if em, ok := v.(map[interface{}]interface{}); ok && len(em) == 0 {
+				v = map[string]interface{}{}
+			}
 			bs, err = json.Marshal(v)
 		}
 		if err != nil {

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -111,6 +111,14 @@ func TestLookup_nullentry(t *testing.T) {
 	})
 }
 
+func TestLookup_emptyMap(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`--config`, `empty_map.yaml`, `--render-as`, `json`, `empty_map`)
+		require.NoError(t, err)
+		require.Equal(t, "{}", string(result))
+	})
+}
+
 func TestLookup_explain(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`--explain`, `--facts`, `facts.yaml`, `interpolate_ca`)

--- a/lookup/testdata/empty_map.yaml
+++ b/lookup/testdata/empty_map.yaml
@@ -1,0 +1,6 @@
+version: 5
+defaults:
+  datadir: hiera
+hierarchy:
+  - name: empty
+    path: empty_map.yaml

--- a/lookup/testdata/hiera/empty_map.yaml
+++ b/lookup/testdata/hiera/empty_map.yaml
@@ -1,0 +1,1 @@
+empty_map: {}


### PR DESCRIPTION
An empty map is reflected into the type `map[interface{}]interface{}`
by pcore. This is correct. There's no way of deciding key or value
type of an empty map. JSON is however only capable of marshaling
maps with string keys. This commit ensures that the corner case that
occurs for empty maps are handled correctly.

Closes #45