### PR TITLE
Use proper JSON data deserialization

### DIFF
--- a/hiera/render.go
+++ b/hiera/render.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/lyraproj/pcore/serialization"
-
+	"github.com/lyraproj/pcore/pcore"
 	"github.com/lyraproj/pcore/px"
+	"github.com/lyraproj/pcore/serialization"
 	"github.com/lyraproj/pcore/types"
 	"github.com/lyraproj/pcore/utils"
 	"gopkg.in/yaml.v3"
@@ -47,7 +47,11 @@ func Render(c px.Context, renderAs RenderName, value px.Value, out io.Writer) {
 				panic(err)
 			}
 		} else {
-			serialization.DataToJson(v, out)
+			he := make([]*types.HashEntry, 0, 2)
+			he = append(he, types.WrapHashEntry2(`rich_data`, types.BooleanFalse))
+			he = append(he, types.WrapHashEntry2(`local_reference`, types.BooleanFalse))
+			serialization.NewSerializer(pcore.RootContext(), types.WrapHash(he)).Convert(value, serialization.NewJsonStreamer(out))
+			utils.WriteByte(out, '\n')
 		}
 	case Binary:
 		bi := types.CoerceTo(c, `lookup value`, types.DefaultBinaryType(), value).(*types.Binary)

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -42,7 +42,7 @@ func TestLookup_defaultHash(t *testing.T) {
 func TestLookup_defaultHash_json(t *testing.T) {
 	result, err := cli.ExecuteLookup(`--default`, `{ x => 'a', y => 9 }`, `--type`, `Hash[String,Variant[String,Integer]]`, `--render-as`, `json`, `foo`)
 	require.NoError(t, err)
-	require.Equal(t, `{"x":"a","y":9}`, string(result))
+	require.Equal(t, "{\"x\":\"a\",\"y\":9}\n", string(result))
 }
 
 func TestLookup_defaultString_s(t *testing.T) {
@@ -115,7 +115,23 @@ func TestLookup_emptyMap(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`--config`, `empty_map.yaml`, `--render-as`, `json`, `empty_map`)
 		require.NoError(t, err)
-		require.Equal(t, "{}", string(result))
+		require.Equal(t, "{}\n", string(result))
+	})
+}
+
+func TestLookup_emptySubMap(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`--config`, `empty_map.yaml`, `--render-as`, `json`, `empty_sub_map`)
+		require.NoError(t, err)
+		require.Equal(t, "{\"x\":\"the x\",\"empty\":{}}\n", string(result))
+	})
+}
+
+func TestLookup_emptySubMapInArray(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`--config`, `empty_map.yaml`, `--render-as`, `json`, `empty_sub_map_in_array`)
+		require.NoError(t, err)
+		require.Equal(t, "[{}]\n", string(result))
 	})
 }
 

--- a/lookup/testdata/hiera/empty_map.yaml
+++ b/lookup/testdata/hiera/empty_map.yaml
@@ -1,1 +1,8 @@
 empty_map: {}
+
+empty_sub_map:
+  x: the x
+  empty: {}
+
+empty_sub_map_in_array:
+  - {}


### PR DESCRIPTION
Switch to use the pcore deserializer for JSON as it is capable of
handling all sorts of data, even empty maps.

This fixes the submap problem reported in #47.