### PR TITLE
Ensure that provider data is cached throughout an invocation

### DIFF
--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -323,6 +323,15 @@ func TestLookupKey_plugin(t *testing.T) {
 	})
 }
 
+func TestDataHash_plugin(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`--config`, `data_hash_plugin.yaml`, `d`)
+		require.NoError(t, err)
+		require.Equal(t, "interpolate c is value c\n", string(result))
+	})
+}
+
 func TestDataHash_refuseToDie(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {

--- a/lookup/testdata/data_hash_plugin.yaml
+++ b/lookup/testdata/data_hash_plugin.yaml
@@ -1,0 +1,6 @@
+version: 5
+
+hierarchy:
+  - name: Plugin
+    data_hash: test_data_hash
+    pluginfile: hieratestplugin

--- a/lookup/testdata/hieratestplugin/hieratestplugin.go
+++ b/lookup/testdata/hieratestplugin/hieratestplugin.go
@@ -3,6 +3,8 @@ package main
 import (
 	"errors"
 
+	"github.com/lyraproj/dgo/vf"
+
 	"github.com/lyraproj/dgo/dgo"
 	"github.com/lyraproj/hierasdk/hiera"
 	"github.com/lyraproj/hierasdk/plugin"
@@ -11,6 +13,7 @@ import (
 
 func main() {
 	register.LookupKey(`test_lookup_key`, lookupOption)
+	register.DataHash(`test_data_hash`, sampleHash)
 	register.DataHash(`test_refuse_to_die`, refuseToDie)
 	register.DataHash(`test_panic`, panicAttack)
 	plugin.ServeAndExit()
@@ -19,6 +22,10 @@ func main() {
 // lookupOption returns the option for the given key or nil if no such option exist
 func lookupOption(c hiera.ProviderContext, key string) dgo.Value {
 	return c.Option(key)
+}
+
+func sampleHash(c hiera.ProviderContext) dgo.Map {
+	return vf.Map(`c`, `value c`, `d`, `interpolate c is %{lookup("c")}`)
 }
 
 // refuseToDie hangs indefinitely


### PR DESCRIPTION
This commit ensures that data obtained from a provider is be cached
during the lifetime of an invocation.

Closes #51