### PR TITLE
Restrict docker build

### DIFF
--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -1,10 +1,11 @@
 name: Docker Image Build + Push
 
-on: [push]
-  branches:
-    - master
-  tags:
-    - v*
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
 
 jobs:
 

--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -1,11 +1,15 @@
 name: Docker Image Build + Push
 
 on: [push]
+  branches:
+    - master
+  tags:
+    - v*
 
 jobs:
 
   build:
- 
+    if: github.repository == "lyraproj/hiera"
     runs-on: ubuntu-latest
  
     steps:


### PR DESCRIPTION
Previously the workflow ran on any repository, on any push, which was expensive and would fail on anything except the main lyraproj fork which has the docker hub secrets configured.

Now it restricts the execution to pushes to `master` or a versioned tag, and only performs the build stage if it's acting in the context of the main fork.

(Unfortunately the `if` key is not available as a conditional for top level execution under `on`, only as a gate against particular `jobs`.