### PR TITLE
Increase http client timeout

### DIFF
--- a/internal/pluginloader.go
+++ b/internal/pluginloader.go
@@ -329,7 +329,7 @@ func (p *plugin) callPlugin(luType, name string, params url.Values) px.Value {
 		ad.RawQuery = params.Encode()
 	}
 	us := ad.String()
-	client := http.Client{Timeout: time.Duration(500 * time.Millisecond)}
+	client := http.Client{Timeout: time.Duration(time.Second * 5)}
 	resp, err := client.Get(us)
 	if err != nil {
 		log.Error(err.Error())


### PR DESCRIPTION
Have seen some timeout errors when calling plugins:

```
##[error]Invoke-Process : time="2019-11-19T16:16:33Z" level=error msg="Get http://127.0.0.1:10000/data_hash/terraform_backend?options=%7B%22backend%22%3A%22azurerm%22%2C%22config%22%3A%7B%22storage_account_name%22%3A%22xxx%22%2C%22container_name%22%3A%22tfstate%22%2C%22access_key%22%3A%22xxx%22%2C%22key%22%3A%22xxx.tfstate%22%7D%7D: net/http: request canceled (Client.Timeout exceeded while awaiting headers)"
```