### PR TITLE
Ensure correct handling of plugin lifecycle

### DIFF
--- a/cli/hiera.go
+++ b/cli/hiera.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/lyraproj/hiera/internal"
-
 	"github.com/lyraproj/hiera/hiera"
 	"github.com/lyraproj/hiera/hieraapi"
 	"github.com/lyraproj/hiera/provider"
@@ -118,8 +116,6 @@ func cmdLookup(cmd *cobra.Command, args []string) error {
 
 	return hiera.TryWithParent(context.Background(), provider.MuxLookupKey, configOptions, func(c px.Context) error {
 		c.Set(`logLevel`, px.LogLevelFromString(logLevel))
-		defer internal.KillPlugins()
-
 		hiera.LookupAndRender(c, &cmdOpts, args, cmd.OutOrStdout())
 		return nil
 	})

--- a/hiera/hiera.go
+++ b/hiera/hiera.go
@@ -100,6 +100,7 @@ func Lookup2(
 func TryWithParent(parent context.Context, tp hieraapi.LookupKey, options map[string]px.Value, consumer func(px.Context) error) error {
 	return pcore.TryWithParent(parent, func(c px.Context) error {
 		internal.InitContext(c, tp, options)
+		defer internal.KillPlugins(c)
 		return consumer(c)
 	})
 }
@@ -109,6 +110,7 @@ func TryWithParent(parent context.Context, tp hieraapi.LookupKey, options map[st
 func DoWithParent(parent context.Context, tp hieraapi.LookupKey, options map[string]px.Value, consumer func(px.Context)) {
 	pcore.DoWithParent(parent, func(c px.Context) {
 		internal.InitContext(c, tp, options)
+		defer internal.KillPlugins(c)
 		consumer(c)
 	})
 }

--- a/hieraserver/rest/rest.go
+++ b/hieraserver/rest/rest.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/lyraproj/hiera/hiera"
 	"github.com/lyraproj/hiera/hieraapi"
-	"github.com/lyraproj/hiera/internal"
 	"github.com/lyraproj/hiera/provider"
 	"github.com/lyraproj/issue/issue"
 	"github.com/lyraproj/pcore/px"
@@ -68,7 +67,6 @@ func startServer(cmd *cobra.Command, _ []string) {
 
 	hiera.DoWithParent(context.Background(), provider.MuxLookupKey, configOptions, func(ctx px.Context) {
 		ctx.Set(`logLevel`, px.LogLevelFromString(logLevel))
-		defer internal.KillPlugins()
 		router := CreateRouter(ctx)
 		err := http.ListenAndServe(":"+strconv.Itoa(port), router)
 		if err != nil {

--- a/lookup/testdata/data_hash_plugin.yaml
+++ b/lookup/testdata/data_hash_plugin.yaml
@@ -1,6 +1,16 @@
 version: 5
 
 hierarchy:
-  - name: Plugin
+  - name: Plugin 1
     data_hash: test_data_hash
     pluginfile: hieratestplugin
+    options:
+      the_hash:
+        a: value a
+        b: value b
+  - name: Plugin 2
+    data_hash: test_data_hash
+    pluginfile: hieratestplugin
+    options:
+      the_hash:
+        c: value c

--- a/lookup/testdata/hieratestplugin/hieratestplugin.go
+++ b/lookup/testdata/hieratestplugin/hieratestplugin.go
@@ -25,7 +25,11 @@ func lookupOption(c hiera.ProviderContext, key string) dgo.Value {
 }
 
 func sampleHash(c hiera.ProviderContext) dgo.Map {
-	return vf.Map(`c`, `value c`, `d`, `interpolate c is %{lookup("c")}`)
+	h := c.Option(`the_hash`).(dgo.Map)
+	if h.Get(`c`) != nil {
+		h = h.Merge(vf.Map(`d`, `interpolate c is %{lookup("c")}`))
+	}
+	return h
 }
 
 // refuseToDie hangs indefinitely


### PR DESCRIPTION
This commit ensures that loaded plugins have the same lifecycle as the
session that loads them. It does this by attaching the actual plugin
registry to the session together with a loader that caches loaded
plugins. Plugins are loaded in the session are then reused until the
session itself terminates and all loaded plugins are killed.

Closes #55