### PR TITLE
Support plugins with unix socket transport.

### DIFF
--- a/internal/pluginloader.go
+++ b/internal/pluginloader.go
@@ -70,18 +70,18 @@ func (r *pluginRegistry) stopAll() {
 }
 
 // attempts to extract unix socket variable form context
-func extractUnixSocketFromContext(c px.Context) string {
+func extractUnixSocketDirFromContext(c px.Context) string {
 	pl, ok := c.DefiningLoader().(*pluginLoader)
 	if !ok {
 		return ""
 	}
 
-	socket, ok := pl.he.OptionsMap()["unixSocket"]
+	socketDir, ok := pl.he.OptionsMap()["unixSocketDir"]
 	if !ok {
 		return ""
 	}
 
-	return socket.String()
+	return socketDir.String()
 }
 
 // startPlugin will start the plugin loaded from the given path and register the functions that it makes available
@@ -102,8 +102,8 @@ func (r *pluginRegistry) startPlugin(c px.Context, path string, loader px.Defini
 	cmd := exec.Command(path)
 	cmd.Env = []string{`HIERA_MAGIC_COOKIE=` + strconv.Itoa(hiera.MagicCookie)}
 
-	if socket := extractUnixSocketFromContext(c); socket != "" {
-		cmd.Env = append(cmd.Env, `HIERA_PLUGIN_SOCKET=`+socket)
+	if socketDir := extractUnixSocketDirFromContext(c); socketDir != "" {
+		cmd.Env = append(cmd.Env, `HIERA_PLUGIN_SOCKET_DIR=`+socketDir)
 	}
 
 	createPipe := func(name string, fn func() (io.ReadCloser, error)) io.ReadCloser {

--- a/internal/pluginloader.go
+++ b/internal/pluginloader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -40,6 +41,7 @@ type plugin struct {
 	process   *os.Process
 	path      string
 	addr      string
+	network   string
 	functions map[string]interface{}
 }
 
@@ -230,6 +232,11 @@ func (p *plugin) initialize(meta map[string]interface{}) {
 	if !ok {
 		panic(fmt.Errorf(`plugin %s did not provide a valid address`, p.path))
 	}
+	p.network, ok = meta[`network`].(string)
+	if !ok {
+		log.Printf(`plugin %s did not provide a valid network, assuming tcp`, p.path)
+		p.network = `tcp`
+	}
 	p.functions, ok = meta[`functions`].(map[string]interface{})
 	if !ok {
 		panic(fmt.Errorf(`plugin %s did not provide a valid functions map`, p.path))
@@ -312,7 +319,14 @@ func makeOptions(sc hieraapi.ServerContext) url.Values {
 }
 
 func (p *plugin) callPlugin(luType, name string, params url.Values) px.Value {
-	ad, err := url.Parse(fmt.Sprintf(`http://%s/%s/%s`, p.addr, luType, name))
+	var ad *url.URL
+	var err error
+
+	if p.network == "unix" {
+		ad, err = url.Parse(fmt.Sprintf(`http://%s/%s/%s`, p.network, luType, name))
+	} else {
+		ad, err = url.Parse(fmt.Sprintf(`http://%s/%s/%s`, p.addr, luType, name))
+	}
 	if err != nil {
 		panic(err)
 	}
@@ -320,7 +334,14 @@ func (p *plugin) callPlugin(luType, name string, params url.Values) px.Value {
 		ad.RawQuery = params.Encode()
 	}
 	us := ad.String()
-	client := http.Client{Timeout: time.Duration(time.Second * 5)}
+	client := http.Client{
+		Timeout: time.Duration(time.Second * 5),
+		Transport: &http.Transport{
+			Dial: func(_, _ string) (net.Conn, error) {
+				return net.Dial(p.network, p.addr)
+			},
+		},
+	}
 	resp, err := client.Get(us)
 	if err != nil {
 		log.Error(err.Error())

--- a/internal/pluginloader.go
+++ b/internal/pluginloader.go
@@ -457,10 +457,10 @@ func extractOptFromContext(c px.Context, key string) string {
 		return ""
 	}
 
-	socketDir, ok := pl.he.OptionsMap()[key]
+	opt, ok := pl.he.OptionsMap()[key]
 	if !ok {
 		return ""
 	}
 
-	return socketDir.String()
+	return opt.String()
 }


### PR DESCRIPTION
Hello

Would you be interested in a feature that adds support for hiera plugins communicating via unix
sockets. Unix sockets are more secure then tcp sockets listening on
localhost which is important for hiera plugins serving secrets.

This is server side of the feature. 
SDK side of the feature can be reviewed via https://github.com/lyraproj/hierasdk/pull/3