### PR TITLE
Don't initialize a TLS object if keys/certs are empty

### DIFF
--- a/hieraserver/rest/rest.go
+++ b/hieraserver/rest/rest.go
@@ -165,10 +165,10 @@ func loadCertPool(pemFile string) (*x509.CertPool, error) {
 }
 
 func makeTLSconfig() (*tls.Config, error) {
-	tlsConfig := new(tls.Config)
 	if sslCert == "" || sslKey == "" {
-		return tlsConfig, nil
+		return nil, nil
 	}
+	tlsConfig := new(tls.Config)
 
 	cert, err := tls.LoadX509KeyPair(sslCert, sslKey)
 	if err != nil {


### PR DESCRIPTION
Prior to this commit, changes in #60 caused an initialized
but non-functional tlsConfig object to skip the non-SSL
listener startup, which would fail.

There might be a more sophisticated fix, but this wfm...

Fixes #62