### PR TITLE
Ensure that leading slash is removed when using loader path

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"unicode"
 
 	"github.com/lyraproj/dgo/streamer/pcore"
 
@@ -265,6 +266,12 @@ func (s *session) createFunctionLoader(l dgo.Loader) dgo.Loader {
 func (s *session) createPluginLoader(p dgo.Loader) dgo.Loader {
 	var pluginFinder = func(l dgo.Loader, _ string) interface{} {
 		an := l.AbsoluteName()
+
+		// In Windows, the path might start with a slash followed by a drive letter. If it does, the slash
+		// must be removed.
+		if runtime.GOOS == "windows" && len(an) > 3 && an[0] == '/' && unicode.IsLetter(rune(an[1])) && an[2] == ':' && an[3] == '/' {
+			an = an[1:]
+		}
 
 		// Strip everything up to '/plugin/'
 		ix := strings.Index(an, `/plugin/`)


### PR DESCRIPTION
The plugin loader builds a hierarchy of loaders that matches the
path in the file system for where the plugins are located. In
windows, this means that the first part of the hierarchy is named
something similar to "C:" and hence results in a path that starts
with "/C:". That path cannot be used without first stripping of
the leading slash. This commit ensures that this happens on
windows.

Closes #64