### PR TITLE
Windows socket fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/sys v0.0.0-20200117145432-59e60aa80a0c // indirect
+	golang.org/x/sys v0.0.0-20200117145432-59e60aa80a0c
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2
 )

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -12,7 +12,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -117,17 +116,6 @@ func getUnixSocketDir(opts dgo.Map) string {
 		return v
 	}
 	return defaultUnixSocketDir
-}
-
-// getDefaultPluginTransport returns the plugin transport method to use
-// for Windows this can be unix if the OS build is 17063 or above,
-// otherwise tcp is used
-// https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
-func getDefaultPluginTransport() string {
-	if runtime.GOOS == "windows" && !isBuild17063() {
-		return "tcp"
-	}
-	return "unix"
 }
 
 // getPluginTransport resolves value of pluginTransport

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -105,6 +105,8 @@ func ignoreOut(cmdOut io.Reader, wGroup *sync.WaitGroup) {
 	}
 }
 
+var pluginTransportUnix = "unix"
+var pluginTransportTcp = "tcp"
 var defaultUnixSocketDir = "/tmp"
 
 // getUnixSocketDir resolves value of unixSocketDir
@@ -124,8 +126,8 @@ func getPluginTransport(opts dgo.Map) string {
 		s := v.GoString()
 		switch s {
 		case
-			"unix",
-			"tcp":
+			pluginTransportUnix,
+			pluginTransportTcp:
 			return s
 		}
 	}
@@ -315,7 +317,7 @@ func (p *plugin) callPlugin(luType, name string, params url.Values) dgo.Value {
 	var ad *url.URL
 	var err error
 
-	if p.network == "unix" {
+	if p.network == pluginTransportUnix {
 		ad, err = url.Parse(fmt.Sprintf(`http://%s/%s/%s`, p.network, luType, name))
 	} else {
 		ad, err = url.Parse(fmt.Sprintf(`http://%s/%s/%s`, p.addr, luType, name))

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -105,8 +105,9 @@ func ignoreOut(cmdOut io.Reader, wGroup *sync.WaitGroup) {
 	}
 }
 
-var pluginTransportUnix = "unix"
-var pluginTransportTcp = "tcp"
+const pluginTransportUnix = "unix"
+const pluginTransportTCP = "tcp"
+
 var defaultUnixSocketDir = "/tmp"
 
 // getUnixSocketDir resolves value of unixSocketDir
@@ -127,7 +128,7 @@ func getPluginTransport(opts dgo.Map) string {
 		switch s {
 		case
 			pluginTransportUnix,
-			pluginTransportTcp:
+			pluginTransportTCP:
 			return s
 		}
 	}

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -25,7 +25,6 @@ import (
 	"github.com/lyraproj/dgo/vf"
 	"github.com/lyraproj/hierasdk/hiera"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/sys/windows/registry"
 )
 
 // a plugin corresponds to a loaded process
@@ -125,24 +124,8 @@ func getUnixSocketDir(opts dgo.Map) string {
 // otherwise tcp is used
 // https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 func getDefaultPluginTransport() string {
-	// get the Windows build number from the registry
-	if runtime.GOOS == "windows" {
-		k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.READ)
-		if err != nil {
-			return "tcp"
-		}
-		defer k.Close()
-		s, _, err := k.GetStringValue("CurrentBuild")
-		if err != nil {
-			return "tcp"
-		}
-		ver, err := strconv.Atoi(s)
-		if err != nil {
-			return "tcp"
-		}
-		if ver < 17063 {
-			return "tcp"
-		}
+	if runtime.GOOS == "windows" && !isBuild17063() {
+		return "tcp"
 	}
 	return "unix"
 }

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -120,7 +120,12 @@ func getUnixSocketDir(opts dgo.Map) string {
 	return defaultUnixSocketDir
 }
 
+// getDefaultPluginTransport returns the plugin transport method to use
+// for Windows this can be unix if the OS build is 17063 or above,
+// otherwise tcp is used
+// https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 func getDefaultPluginTransport() string {
+	// get the Windows build number from the registry
 	if runtime.GOOS == "windows" {
 		k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.READ)
 		if err != nil {

--- a/session/plugintransport_linux.go
+++ b/session/plugintransport_linux.go
@@ -3,5 +3,5 @@
 package session
 
 func getDefaultPluginTransport() string {
-	return "unix"
+	return pluginTransportUnix
 }

--- a/session/plugintransport_linux.go
+++ b/session/plugintransport_linux.go
@@ -1,0 +1,7 @@
+// +build linux
+
+package session
+
+func getDefaultPluginTransport() string {
+	return "unix"
+}

--- a/session/plugintransport_windows.go
+++ b/session/plugintransport_windows.go
@@ -15,7 +15,7 @@ func getDefaultPluginTransport() string {
 	if isBuild17063() {
 		return pluginTransportUnix
 	}
-	return pluginTransportTcp
+	return pluginTransportTCP
 }
 
 // isBuild17063 gets the Windows build number from the registry

--- a/session/plugintransport_windows.go
+++ b/session/plugintransport_windows.go
@@ -7,6 +7,17 @@ import (
 	"strconv"
 )
 
+// getDefaultPluginTransport returns the plugin transport method to use.
+// For Windows this can be unix if the OS build is 17063 or above,
+// otherwise tcp is used
+// https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+func getDefaultPluginTransport() string {
+	if isBuild17063() {
+		return "unix"
+	}
+	return "tcp"
+}
+
 // isBuild17063 gets the Windows build number from the registry
 func isBuild17063() bool {
 	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.READ)

--- a/session/plugintransport_windows.go
+++ b/session/plugintransport_windows.go
@@ -13,9 +13,9 @@ import (
 // https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
 func getDefaultPluginTransport() string {
 	if isBuild17063() {
-		return "unix"
+		return pluginTransportUnix
 	}
-	return "tcp"
+	return pluginTransportTcp
 }
 
 // isBuild17063 gets the Windows build number from the registry

--- a/session/session.go
+++ b/session/session.go
@@ -267,16 +267,16 @@ func (s *session) createPluginLoader(p dgo.Loader) dgo.Loader {
 	var pluginFinder = func(l dgo.Loader, _ string) interface{} {
 		an := l.AbsoluteName()
 
-		// In Windows, the path might start with a slash followed by a drive letter. If it does, the slash
-		// must be removed.
-		if runtime.GOOS == "windows" && len(an) > 3 && an[0] == '/' && unicode.IsLetter(rune(an[1])) && an[2] == ':' && an[3] == '/' {
-			an = an[1:]
-		}
-
 		// Strip everything up to '/plugin/'
 		ix := strings.Index(an, `/plugin/`)
 		if ix < 0 {
 			return nil
+		}
+		path := an[ix+7:]
+		// In Windows, the path might start with a slash followed by a drive letter. If it does, the slash
+		// must be removed.
+		if runtime.GOOS == "windows" && len(path) > 3 && path[0] == '/' && unicode.IsLetter(rune(path[1])) && path[2] == ':' && path[3] == '/' {
+			path = path[1:]
 		}
 
 		// Get the plugin registry for this session
@@ -286,7 +286,7 @@ func (s *session) createPluginLoader(p dgo.Loader) dgo.Loader {
 		} else {
 			return nil
 		}
-		return allPlugins.startPlugin(s.SessionOptions(), an[ix+7:])
+		return allPlugins.startPlugin(s.SessionOptions(), path)
 	}
 
 	var pluginNamespace func(l dgo.Loader, name string) dgo.Loader

--- a/session/windows.go
+++ b/session/windows.go
@@ -1,0 +1,26 @@
+// +build windows
+
+package session
+
+import (
+	"golang.org/x/sys/windows/registry"
+	"strconv"
+)
+
+// isBuild17063 gets the Windows build number from the registry
+func isBuild17063() bool {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.READ)
+	if err != nil {
+		return false
+	}
+	defer k.Close()
+	s, _, err := k.GetStringValue("CurrentBuild")
+	if err != nil {
+		return false
+	}
+	ver, err := strconv.Atoi(s)
+	if err != nil {
+		return false
+	}
+	return ver >= 17063
+}


### PR DESCRIPTION
Autodetect when to use unix sockets from Windows build number (based on https://go-review.googlesource.com/c/go/+/125456/7/src/net/unixsock_windows_test.go#17)
Update path correction for windows as was still getting the path starting with `/`