### PR TITLE
Ensure that interpolation with lookup method handles not found

### DIFF
--- a/hiera/hiera_test.go
+++ b/hiera/hiera_test.go
@@ -77,7 +77,7 @@ func TestLookup_interpolateAlias(t *testing.T) {
 }
 
 func TestLookup_interpolateBadAlias(t *testing.T) {
-	require.NotOk(t, `'alias' interpolation is only permitted if the expression is equal to the entire string`,
+	require.NotOk(t, `'alias'/'strict_alias' interpolation is only permitted if the expression is equal to the entire string`,
 		hiera.TryWithParent(context.Background(), provider.YamlLookupKey, options, func(hs api.Session) error {
 			hiera.Lookup(hs.Invocation(nil, nil), `ipBadAlias`, nil, options)
 			return nil

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -168,6 +168,14 @@ func TestLookup_alias(t *testing.T) {
 	})
 }
 
+func TestLookup_strictAlias(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`strict_alias_array`)
+		require.NoError(t, err)
+		require.Equal(t, "- one\n- two\n- three\n", string(result))
+	})
+}
+
 func TestLookup_lookupNothing(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`lookup_nothing`)
@@ -179,6 +187,14 @@ func TestLookup_lookupNothing(t *testing.T) {
 func TestLookup_aliasNothing(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`alias_nothing`)
+		require.NoError(t, err)
+		require.Equal(t, "\"\"\n", string(result))
+	})
+}
+
+func TestLookup_strictAliasNothing(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`strict_alias_nothing`)
 		require.NoError(t, err)
 		require.Equal(t, ``, string(result))
 	})

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -160,11 +160,27 @@ func TestLookup_lookup(t *testing.T) {
 	})
 }
 
+func TestLookup_alias(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`alias_array`)
+		require.NoError(t, err)
+		require.Equal(t, "- one\n- two\n- three\n", string(result))
+	})
+}
+
 func TestLookup_lookupNothing(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`lookup_nothing`)
 		require.NoError(t, err)
 		require.Equal(t, "\"\"\n", string(result))
+	})
+}
+
+func TestLookup_aliasNothing(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`alias_nothing`)
+		require.NoError(t, err)
+		require.Equal(t, ``, string(result))
 	})
 }
 

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -25,6 +25,12 @@ func TestLookup_defaultString(t *testing.T) {
 	require.Equal(t, "\"23\"\n", string(result))
 }
 
+func TestLookup_notFound(t *testing.T) {
+	result, err := cli.ExecuteLookup(`foo`)
+	require.NoError(t, err)
+	require.Equal(t, "", string(result))
+}
+
 func TestLookup_defaultEmptyString(t *testing.T) {
 	result, err := cli.ExecuteLookup(`--default`, ``, `foo`)
 	require.NoError(t, err)
@@ -143,6 +149,22 @@ func TestLookup_sensitive(t *testing.T) {
 		result, err = cli.ExecuteLookup(`sense`)
 		require.NoError(t, err)
 		require.Equal(t, "__type: sensitive\n__value: Don't reveal this\n", string(result))
+	})
+}
+
+func TestLookup_lookup(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`lookup_array`)
+		require.NoError(t, err)
+		require.Equal(t, "'{\"one\",\"two\",\"three\"}'\n", string(result))
+	})
+}
+
+func TestLookup_lookupNothing(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`lookup_nothing`)
+		require.NoError(t, err)
+		require.Equal(t, "\"\"\n", string(result))
 	})
 }
 

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -21,9 +21,13 @@ lookup_array: '%{lookup("array")}'
 
 alias_array: '%{alias("array")}'
 
+strict_alias_array: '%{strict_alias("array")}'
+
 lookup_nothing: '%{lookup("nothing")}'
 
 alias_nothing: '%{alias("nothing")}'
+
+strict_alias_nothing: '%{strict_alias("nothing")}'
 
 lookup_options:
   hash:

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -17,6 +17,10 @@ sense: Don't reveal this
 nullentry:
   nv: null
 
+lookup_array: '%{lookup("array")}'
+
+lookup_nothing: '%{lookup("nothing")}'
+
 lookup_options:
   hash:
     merge: deep

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -19,7 +19,11 @@ nullentry:
 
 lookup_array: '%{lookup("array")}'
 
+alias_array: '%{alias("array")}'
+
 lookup_nothing: '%{lookup("nothing")}'
+
+alias_nothing: '%{alias("nothing")}'
 
 lookup_options:
   hash:

--- a/session/interpolate.go
+++ b/session/interpolate.go
@@ -133,6 +133,9 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 					result = val
 					return ``
 				}
+				if val == nil {
+					return ``
+				}
 				return val.String()
 			}
 		})

--- a/session/interpolate.go
+++ b/session/interpolate.go
@@ -108,12 +108,12 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 
 	return ic.WithInterpolation(str, func() dgo.Value {
 		var result dgo.Value
+		var methodKey int
 		str = iplPattern.ReplaceAllStringFunc(str, func(match string) string {
 			expr := strings.TrimSpace(match[2 : len(match)-1])
 			if emptyInterpolations[expr] {
 				return ``
 			}
-			var methodKey int
 			methodKey, expr = getMethodAndData(expr, allowMethods)
 			if methodKey == aliasMethod && match != str {
 				panic(errors.New(`'alias' interpolation is only permitted if the expression is equal to the entire string`))
@@ -139,7 +139,7 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 				return val.String()
 			}
 		})
-		if result == nil {
+		if result == nil && methodKey != aliasMethod {
 			result = vf.String(str)
 		}
 		return result

--- a/session/interpolate.go
+++ b/session/interpolate.go
@@ -68,14 +68,23 @@ func (ic *ivContext) doInterpolate(value dgo.Value, allowMethods bool) (dgo.Valu
 	return value, false
 }
 
-const scopeMethod = 1
-const aliasMethod = 2
-const lookupMethod = 3
-const literalMethod = 4
+type iplMethod int
+
+const (
+	scopeMethod = iplMethod(iota)
+	aliasMethod
+	strictAliasMethod
+	lookupMethod
+	literalMethod
+)
+
+func (m iplMethod) isAlias() bool {
+	return m == aliasMethod || m == strictAliasMethod
+}
 
 var methodMatch = regexp.MustCompile(`^(\w+)\((?:["]([^"]+)["]|[']([^']+)['])\)$`)
 
-func getMethodAndData(expr string, allowMethods bool) (int, string) {
+func getMethodAndData(expr string, allowMethods bool) (iplMethod, string) {
 	if groups := methodMatch.FindStringSubmatch(expr); groups != nil {
 		if !allowMethods {
 			panic(errors.New(`interpolation using method syntax is not allowed in this context`))
@@ -87,6 +96,8 @@ func getMethodAndData(expr string, allowMethods bool) (int, string) {
 		switch groups[1] {
 		case `alias`:
 			return aliasMethod, data
+		case `strict_alias`:
+			return strictAliasMethod, data
 		case `hiera`, `lookup`:
 			return lookupMethod, data
 		case `literal`:
@@ -108,15 +119,15 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 
 	return ic.WithInterpolation(str, func() dgo.Value {
 		var result dgo.Value
-		var methodKey int
+		var methodKey iplMethod
 		str = iplPattern.ReplaceAllStringFunc(str, func(match string) string {
 			expr := strings.TrimSpace(match[2 : len(match)-1])
 			if emptyInterpolations[expr] {
 				return ``
 			}
 			methodKey, expr = getMethodAndData(expr, allowMethods)
-			if methodKey == aliasMethod && match != str {
-				panic(errors.New(`'alias' interpolation is only permitted if the expression is equal to the entire string`))
+			if methodKey.isAlias() && match != str {
+				panic(errors.New(`'alias'/'strict_alias' interpolation is only permitted if the expression is equal to the entire string`))
 			}
 
 			switch methodKey {
@@ -129,7 +140,7 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 				return ``
 			default:
 				val := ic.Lookup(api.NewKey(expr), nil)
-				if methodKey == aliasMethod {
+				if methodKey.isAlias() {
 					result = val
 					return ``
 				}
@@ -139,7 +150,7 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 				return val.String()
 			}
 		})
-		if result == nil && methodKey != aliasMethod {
+		if result == nil && methodKey != strictAliasMethod {
 			result = vf.String(str)
 		}
 		return result


### PR DESCRIPTION
An interpolation using the lookup method must treat a non existent
value as an empty string.

Closes #69