### PR TITLE
Cleanly terminate Windows processes

### DIFF
--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -145,13 +145,7 @@ func (r *pluginRegistry) startPlugin(opts dgo.Map, path string) dgo.Value {
 			return p.functionMap()
 		}
 	}
-
-	cmd := exec.Command(path)
-	cmd.Env = os.Environ()
-	cmd.Env = append(cmd.Env, `HIERA_MAGIC_COOKIE=`+strconv.Itoa(hiera.MagicCookie))
-	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_SOCKET_DIR=`+getUnixSocketDir(opts))
-	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_TRANSPORT=`+getPluginTransport(opts))
-	cmd.SysProcAttr = procAttrs
+	cmd := initCmd(opts, path)
 	cmdErr := createPipe(path, `stderr`, cmd.StderrPipe)
 	cmdOut := createPipe(path, `stdout`, cmd.StdoutPipe)
 	if err := cmd.Start(); err != nil {
@@ -198,6 +192,16 @@ func (r *pluginRegistry) startPlugin(opts dgo.Map, path string) dgo.Value {
 	r.plugins[path] = p
 
 	return p.functionMap()
+}
+
+func initCmd(opts dgo.Map, path string) *exec.Cmd {
+	cmd := exec.Command(path)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, `HIERA_MAGIC_COOKIE=`+strconv.Itoa(hiera.MagicCookie))
+	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_SOCKET_DIR=`+getUnixSocketDir(opts))
+	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_TRANSPORT=`+getPluginTransport(opts))
+	cmd.SysProcAttr = procAttrs
+	return cmd
 }
 
 func (p *plugin) kill() {

--- a/session/pluginloader.go
+++ b/session/pluginloader.go
@@ -15,7 +15,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/lyraproj/dgo/dgo"
@@ -148,10 +147,11 @@ func (r *pluginRegistry) startPlugin(opts dgo.Map, path string) dgo.Value {
 	}
 
 	cmd := exec.Command(path)
-	cmd.Env = []string{`HIERA_MAGIC_COOKIE=` + strconv.Itoa(hiera.MagicCookie)}
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, `HIERA_MAGIC_COOKIE=`+strconv.Itoa(hiera.MagicCookie))
 	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_SOCKET_DIR=`+getUnixSocketDir(opts))
 	cmd.Env = append(cmd.Env, `HIERA_PLUGIN_TRANSPORT=`+getPluginTransport(opts))
-
+	cmd.SysProcAttr = procAttrs
 	cmdErr := createPipe(path, `stderr`, cmd.StderrPipe)
 	cmdOut := createPipe(path, `stdout`, cmd.StdoutPipe)
 	if err := cmd.Start(); err != nil {
@@ -213,9 +213,8 @@ func (p *plugin) kill() {
 		p.lock.Unlock()
 	}()
 
-	// SIGINT on windows will fail
 	graceful := true
-	if err := process.Signal(syscall.SIGINT); err != nil {
+	if err := terminateProc(process); err != nil {
 		graceful = false
 	}
 
@@ -231,7 +230,7 @@ func (p *plugin) kill() {
 			_ = process.Kill()
 		}
 	} else {
-		// Windows. Just kill it!
+		// Graceful terminate failed. Just kill it!
 		_ = process.Kill()
 	}
 }

--- a/session/proc_unix.go
+++ b/session/proc_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package session
+
+import (
+	"os"
+	"os/signal"
+)
+
+var procAttrs = nil
+
+func terminateProc(process *os.Process) error {
+	process.Signal(syscall.SIGINT)
+}

--- a/session/proc_unix.go
+++ b/session/proc_unix.go
@@ -4,11 +4,11 @@ package session
 
 import (
 	"os"
-	"os/signal"
+	"syscall"
 )
 
-var procAttrs = nil
+var procAttrs = &syscall.SysProcAttr{}
 
 func terminateProc(process *os.Process) error {
-	process.Signal(syscall.SIGINT)
+	return process.Signal(syscall.SIGINT)
 }

--- a/session/proc_windows.go
+++ b/session/proc_windows.go
@@ -50,9 +50,5 @@ func terminateProc(process *os.Process) error {
 	if r1 == 0 {
 		return err
 	}
-	r1, _, err = f.Call(windows.CTRL_C_EVENT, uintptr(pid))
-	if r1 == 0 {
-		return err
-	}
 	return nil
 }

--- a/session/proc_windows.go
+++ b/session/proc_windows.go
@@ -1,0 +1,58 @@
+// +build windows
+
+package session
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+var procAttrs = &windows.SysProcAttr{
+	CreationFlags: windows.CREATE_UNICODE_ENVIRONMENT | windows.CREATE_NEW_PROCESS_GROUP,
+}
+
+// Windows doesn't understand SIGINT, instead we attach a console
+// to the process and send CTRL+BREAK / CTRL+C
+// Code from https://github.com/mattn/goreman/blob/master/proc_windows.go
+func terminateProc(process *os.Process) error {
+	dll, err := windows.LoadDLL("kernel32.dll")
+	if err != nil {
+		return err
+	}
+	defer dll.Release()
+
+	pid := process.Pid
+
+	f, err := dll.FindProc("AttachConsole")
+	if err != nil {
+		return err
+	}
+	r1, _, err := f.Call(uintptr(pid))
+	if r1 == 0 && err != syscall.ERROR_ACCESS_DENIED {
+		return err
+	}
+
+	f, err = dll.FindProc("SetConsoleCtrlHandler")
+	if err != nil {
+		return err
+	}
+	r1, _, err = f.Call(0, 1)
+	if r1 == 0 {
+		return err
+	}
+	f, err = dll.FindProc("GenerateConsoleCtrlEvent")
+	if err != nil {
+		return err
+	}
+	r1, _, err = f.Call(windows.CTRL_BREAK_EVENT, uintptr(pid))
+	if r1 == 0 {
+		return err
+	}
+	r1, _, err = f.Call(windows.CTRL_C_EVENT, uintptr(pid))
+	if r1 == 0 {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Terminate plugins on Windows by sending CTRL+Break / CTRL+C
This ensures the unix sockets are correctly removed, preventing errors when a process is created with the same PID as a previous process

Also pass through the parent environment to plugins, as Terraform backends are often configured using environment variables