### PR TITLE
Ensure proper rendering for JSON and YAML

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -152,6 +152,34 @@ func TestLookup_sensitive(t *testing.T) {
 	})
 }
 
+func TestLookup_renderJSON_NoDedup(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`non-existent`, `--dialect`, `dgo`, `--default`,
+			`{ x: "a string longer than 20 characters in length", y: "a string longer than 20 characters in length" }`,
+			`--render-as`, `json`)
+
+		require.NoError(t, err)
+		require.Equal(t,
+			`{"x":"a string longer than 20 characters in length","y":"a string longer than 20 characters in length"}
+`,
+			string(result))
+	})
+}
+
+func TestLookup_renderYAML_NoDedup(t *testing.T) {
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`non-existent`, `--dialect`, `dgo`, `--default`,
+			`{ x: "a string longer than 20 characters in length", y: "a string longer than 20 characters in length" }`,
+			`--render-as`, `yaml`)
+
+		require.NoError(t, err)
+		require.Equal(t, `x: a string longer than 20 characters in length
+y: a string longer than 20 characters in length
+`,
+			string(result))
+	})
+}
+
 func TestLookup_lookup(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`lookup_array`)


### PR DESCRIPTION
This commit ensures that no deduplification occurs when rendering lookup
results json or yaml.

Closes #74 
