### PR TITLE
(81) Add path to error message for yaml

### DIFF
--- a/api/invocation.go
+++ b/api/invocation.go
@@ -48,7 +48,7 @@ type Invocation interface {
 	MergeHierarchy(key Key, providers []DataProvider, merge MergeStrategy) dgo.Value
 
 	// MergeLocations merges the result of lookups on all locations (or without location) for the
-	//given provider and merge options
+	// given provider and merge options
 	MergeLocations(key Key, provider DataProvider, merge MergeStrategy) dgo.Value
 
 	// ReportText will add the message returned by the given function to the

--- a/provider/yamldata.go
+++ b/provider/yamldata.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -23,11 +24,11 @@ func YamlData(ctx hiera.ProviderContext) dgo.Map {
 		if os.IsNotExist(err) {
 			return vf.Map()
 		}
-		panic(err)
+		panic(fmt.Errorf("Could not read %s: %s", path, err.Error()))
 	}
 	v, err := yaml.Unmarshal(bs)
 	if err != nil {
-		panic(err)
+		panic(fmt.Errorf("Could not unmarshal %s: %s", path, err.Error()))
 	}
 	if data, ok := v.(dgo.Map); ok {
 		return data

--- a/provider/yamldata.go
+++ b/provider/yamldata.go
@@ -24,11 +24,11 @@ func YamlData(ctx hiera.ProviderContext) dgo.Map {
 		if os.IsNotExist(err) {
 			return vf.Map()
 		}
-		panic(fmt.Errorf("Could not read %s: %s", path, err.Error()))
+		panic(fmt.Errorf("could not read %s: %s", path, err.Error()))
 	}
 	v, err := yaml.Unmarshal(bs)
 	if err != nil {
-		panic(fmt.Errorf("Could not unmarshal %s: %s", path, err.Error()))
+		panic(fmt.Errorf("could not unmarshal %s: %s", path, err.Error()))
 	}
 	if data, ok := v.(dgo.Map); ok {
 		return data


### PR DESCRIPTION
This adds the path of the yaml file when `YamlData`
fails to read or unmarshal the file.