### PR TITLE
Ensure that interpolation lookups reset merge strategy

### DIFF
--- a/lookup/testdata/interpolate_fresh.yaml
+++ b/lookup/testdata/interpolate_fresh.yaml
@@ -1,0 +1,11 @@
+version: 5
+
+defaults:
+  datadir: interpolate_fresh
+  data_hash: yaml_data
+
+hierarchy:
+  - name: Common
+    path: common.yaml
+  - name: Defaults
+    path: defaults.yaml

--- a/lookup/testdata/interpolate_fresh/common.yaml
+++ b/lookup/testdata/interpolate_fresh/common.yaml
@@ -1,0 +1,12 @@
+empty_array: []
+
+empty_hash: {}
+
+hash_with_alias:
+  y: Y
+  eh: '%{alias("empty_hash")}'
+  ea: '%{alias("empty_array")}'
+
+lookup_options:
+  hash_with_alias:
+    merge: deep

--- a/lookup/testdata/interpolate_fresh/defaults.yaml
+++ b/lookup/testdata/interpolate_fresh/defaults.yaml
@@ -1,0 +1,12 @@
+empty_array:
+  - one
+  - two
+  - three
+
+empty_hash:
+  one: 1
+  two: 2
+  three: 3
+
+hash_with_alias:
+  x: X

--- a/session/interpolate.go
+++ b/session/interpolate.go
@@ -4,11 +4,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/tada/catch"
-
 	"github.com/lyraproj/dgo/dgo"
 	"github.com/lyraproj/dgo/vf"
 	"github.com/lyraproj/hiera/api"
+	"github.com/tada/catch"
 )
 
 var iplPattern = regexp.MustCompile(`%{[^}]*}`)
@@ -138,7 +137,7 @@ func (ic *ivContext) InterpolateString(str string, allowMethods bool) (dgo.Value
 				}
 				return ``
 			default:
-				val := ic.Lookup(api.NewKey(expr), nil)
+				val := ic.ForSubLookup().Lookup(api.NewKey(expr), nil)
 				if methodKey.isAlias() {
 					result = val
 					return ``

--- a/session/invocation.go
+++ b/session/invocation.go
@@ -4,19 +4,15 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tada/catch"
-
-	"github.com/lyraproj/hiera/merge"
-
-	"github.com/lyraproj/dgo/vf"
-
-	"github.com/lyraproj/dgo/typ"
-
 	"github.com/lyraproj/dgo/dgo"
+	"github.com/lyraproj/dgo/typ"
 	"github.com/lyraproj/dgo/util"
+	"github.com/lyraproj/dgo/vf"
 	"github.com/lyraproj/hiera/api"
 	"github.com/lyraproj/hiera/config"
+	"github.com/lyraproj/hiera/merge"
 	"github.com/lyraproj/hierasdk/hiera"
+	"github.com/tada/catch"
 )
 
 const hieraConfigsPrefix = `HieraConfig:`
@@ -397,6 +393,13 @@ func (ic *ivContext) ForData() api.Invocation {
 		lic.explainer = nil
 	}
 	lic.mode = dataMode
+	return &lic
+}
+
+func (ic *ivContext) ForSubLookup() api.Invocation {
+	lic := *ic
+	lic.strategy = nil
+	lic.mode = topLevelMode
 	return &lic
 }
 


### PR DESCRIPTION
This commit fixes a problem with merge strategy being inherited from
the parent lookup when an interpolation lookup or alias was made.