### PR TITLE
Support looking up multiple keys

### DIFF
--- a/cli/hiera.go
+++ b/cli/hiera.go
@@ -111,7 +111,8 @@ func NewCommand() *cobra.Command {
 		`a key:value or key=value where value is literal expressed using Puppet DSL`)
 	flags.StringArrayVar(&cmdOpts.FactPaths, `facts`, nil,
 		`like --vars but will also make variables available under the "facts" (for compatibility with Puppet's ruby version of Hiera)`)
-	flags.BoolVar(&cmdOpts.MultiValue, `multi-value`, false, ``)
+	flags.BoolVar(&cmdOpts.MultiLookup, `multi-lookup`, false,
+		`lookup all of the keys and output the results as a map`)
 
 	cmd.SetHelpTemplate(helpTemplate)
 	return cmd

--- a/cli/hiera.go
+++ b/cli/hiera.go
@@ -111,6 +111,7 @@ func NewCommand() *cobra.Command {
 		`a key:value or key=value where value is literal expressed using Puppet DSL`)
 	flags.StringArrayVar(&cmdOpts.FactPaths, `facts`, nil,
 		`like --vars but will also make variables available under the "facts" (for compatibility with Puppet's ruby version of Hiera)`)
+	flags.BoolVar(&cmdOpts.MultiValue, `multi-value`, false, ``)
 
 	cmd.SetHelpTemplate(helpTemplate)
 	return cmd

--- a/cli/hiera.go
+++ b/cli/hiera.go
@@ -96,7 +96,7 @@ func NewCommand() *cobra.Command {
 	flags.Var(&dflt, `default`,
 		`a value to return if Hiera can't find a value in data`)
 	flags.StringVar(&cmdOpts.Type, `type`, ``,
-		`assert that the value has the specified type`)
+		`assert that the value has the specified type (if using --all this must be a map)`)
 	flags.StringVar(&dialect, `dialect`, `pcore`,
 		`dialect to use for rich data serialization and parsing of types pcore|dgo'`)
 	flags.StringVar(&cmdOpts.RenderAs, `render-as`, ``,
@@ -111,7 +111,7 @@ func NewCommand() *cobra.Command {
 		`a key:value or key=value where value is literal expressed using Puppet DSL`)
 	flags.StringArrayVar(&cmdOpts.FactPaths, `facts`, nil,
 		`like --vars but will also make variables available under the "facts" (for compatibility with Puppet's ruby version of Hiera)`)
-	flags.BoolVar(&cmdOpts.MultiLookup, `multi-lookup`, false,
+	flags.BoolVar(&cmdOpts.LookupAll, `all`, false,
 		`lookup all of the keys and output the results as a map`)
 
 	cmd.SetHelpTemplate(helpTemplate)

--- a/hiera/hiera.go
+++ b/hiera/hiera.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/lyraproj/dgo/dgo"
+	"github.com/lyraproj/dgo/streamer"
 	"github.com/lyraproj/dgo/typ"
 	"github.com/lyraproj/dgo/util"
 	"github.com/lyraproj/dgo/vf"
@@ -210,11 +211,7 @@ var needParsePrefix = []string{`{`, `[`, `"`, `'`}
 // LookupAndRender performs a lookup using the given command options and arguments and renders the result on the given
 // io.Writer in accordance with the `RenderAs` option.
 func LookupAndRender(c api.Session, opts *CommandOptions, args []string, out io.Writer) bool {
-	tp := typ.Any
-	dl := c.Dialect()
-	if opts.Type != `` {
-		tp = dl.ParseType(nil, vf.String(opts.Type))
-	}
+	tp := parseType(opts.Type, c.Dialect())
 
 	var options dgo.Map
 	if !(opts.Merge == `` || opts.Merge == `first`) {
@@ -245,7 +242,6 @@ func LookupAndRender(c api.Session, opts *CommandOptions, args []string, out io.
 		}
 		found = LookupAll(invocation, args, stp, nil, nil, options)
 	} else {
-
 		found = Lookup2(invocation, args, tp, dv, nil, nil, options, nil)
 	}
 	if explainer != nil {
@@ -267,6 +263,14 @@ func LookupAndRender(c api.Session, opts *CommandOptions, args []string, out io.
 	}
 	Render(c, renderAs, found, out)
 	return true
+}
+
+func parseType(t string, dl streamer.Dialect) dgo.Type {
+	tp := typ.Any
+	if t != `` {
+		tp = dl.ParseType(nil, vf.String(t))
+	}
+	return tp
 }
 
 func parseCommandLineValue(c api.Session, vs string) dgo.Value {

--- a/hiera/hiera.go
+++ b/hiera/hiera.go
@@ -52,7 +52,7 @@ type CommandOptions struct {
 	// ExplainOptions should be set to true to explain how lookup options were found for the lookup
 	ExplainOptions bool
 
-	MultiValue bool
+	MultiLookup bool
 }
 
 // Lookup performs a lookup using the given parameters.
@@ -114,7 +114,24 @@ func Lookup2(
 	return nil
 }
 
-func Lookup3(
+// MultiLookup performs a lookup using the given parameters for all of the names passed in.
+//
+// ic - The lookup invocation
+//
+// names[] - The name or names to lookup
+//
+// valueType - Optional expected type of the found value
+//
+// defaultValue - Optional value to use as default when no value is found
+//
+// override - Optional map to use as override. Values found here are returned immediately (no merge)
+//
+// defaultValuesHash - Optional map to use as the last resort (but before defaultValue)
+//
+// options - Optional map with merge strategy and options
+//
+// defaultFunc - Optional function to produce a default value
+func MultiLookup(
 	ic api.Invocation,
 	names []string,
 	valueType dgo.Type,
@@ -223,8 +240,8 @@ func LookupAndRender(c api.Session, opts *CommandOptions, args []string, out io.
 	}
 
 	var found dgo.Value
-	if opts.MultiValue {
-		found = Lookup3(c.Invocation(createScope(c, opts), explainer), args, tp, dv, nil, nil, options, nil)
+	if opts.MultiLookup {
+		found = MultiLookup(c.Invocation(createScope(c, opts), explainer), args, tp, dv, nil, nil, options, nil)
 	} else {
 		found = Lookup2(c.Invocation(createScope(c, opts), explainer), args, tp, dv, nil, nil, options, nil)
 	}

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -460,7 +460,7 @@ func TestLookup_multi_not_there(t *testing.T) {
 	inTestdata(func() {
 		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--render-as`, `s`, `--multi-lookup`)
 		require.NoError(t, err)
-		require.Equal(t, `{"simple":"value"
+		require.Equal(t, `{"simple":"value"}
 `, string(result))
 	})
 }

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -435,43 +435,51 @@ func TestLookup_issue75(t *testing.T) {
 	}
 }
 
-func TestLookup_multi_json(t *testing.T) {
+func TestLookup_all_json(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {
-		result, err := cli.ExecuteLookup(`hash`, `array`, `--render-as`, `json`, `--multi-lookup`)
+		result, err := cli.ExecuteLookup(`hash`, `array`, `--render-as`, `json`, `--all`)
 		require.NoError(t, err)
 		require.Equal(t, `{"hash":{"one":1,"two":"two","three":{"a":"A","c":"C"}},"array":["one","two","three"]}
 `, string(result))
 	})
 }
 
-func TestLookup_multi_simple(t *testing.T) {
+func TestLookup_all_simple(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {
-		result, err := cli.ExecuteLookup(`simple`, `--render-as`, `s`, `--multi-lookup`)
+		result, err := cli.ExecuteLookup(`simple`, `--render-as`, `s`, `--all`)
 		require.NoError(t, err)
 		require.Equal(t, `{"simple":"value"}
 `, string(result))
 	})
 }
 
-func TestLookup_multi_not_there(t *testing.T) {
+func TestLookup_all_not_there(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {
-		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--render-as`, `s`, `--multi-lookup`)
+		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--render-as`, `s`, `--all`)
 		require.NoError(t, err)
 		require.Equal(t, `{"simple":"value"}
 `, string(result))
 	})
 }
 
-func TestLookup_multi_default(t *testing.T) {
+func TestLookup_all_type(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {
-		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--default`, `something`, `--render-as`, `s`, `--multi-lookup`)
+		result, err := cli.ExecuteLookup(`stringkey`, `intkey`, `--all`, `--dialect`, `dgo`, `--render-as`, `s`, `--type`, `{"stringkey":string,"intkey":int}`)
 		require.NoError(t, err)
-		require.Equal(t, `{"simple":"value","not_there":"something"}
+		require.Equal(t, `{"stringkey":"stringvalue","intkey":1}
 `, string(result))
+	})
+}
+
+func TestLookup_all_invalidtype(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		_, err := cli.ExecuteLookup(`stringkey`, `intkey`, `--all`, `--dialect`, `dgo`, `--render-as`, `s`, `--type`, `{"stringkey":int,"intkey":int}`)
+		require.Error(t, err, `the value 'stringvalue' cannot be converted to an int`)
 	})
 }
 

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -435,6 +435,46 @@ func TestLookup_issue75(t *testing.T) {
 	}
 }
 
+func TestLookup_multi_json(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`hash`, `array`, `--render-as`, `json`, `--multi-lookup`)
+		require.NoError(t, err)
+		require.Equal(t, `{"hash":{"one":1,"two":"two","three":{"a":"A","c":"C"}},"array":["one","two","three"]}
+`, string(result))
+	})
+}
+
+func TestLookup_multi_simple(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`simple`, `--render-as`, `s`, `--multi-lookup`)
+		require.NoError(t, err)
+		require.Equal(t, `{"simple":"value"}
+`, string(result))
+	})
+}
+
+func TestLookup_multi_not_there(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--render-as`, `s`, `--multi-lookup`)
+		require.NoError(t, err)
+		require.Equal(t, `{"simple":"value"
+`, string(result))
+	})
+}
+
+func TestLookup_multi_default(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		result, err := cli.ExecuteLookup(`simple`, `not_there`, `--default`, `something`, `--render-as`, `s`, `--multi-lookup`)
+		require.NoError(t, err)
+		require.Equal(t, `{"simple":"value","not_there":"something"}
+`, string(result))
+	})
+}
+
 /*
 func TestDataHash_refuseToDie(t *testing.T) {
 	ensureTestPlugin(t)

--- a/lookup/lookup_test.go
+++ b/lookup/lookup_test.go
@@ -475,11 +475,19 @@ func TestLookup_all_type(t *testing.T) {
 	})
 }
 
-func TestLookup_all_invalidtype(t *testing.T) {
+func TestLookup_all_invalid_type(t *testing.T) {
 	ensureTestPlugin(t)
 	inTestdata(func() {
 		_, err := cli.ExecuteLookup(`stringkey`, `intkey`, `--all`, `--dialect`, `dgo`, `--render-as`, `s`, `--type`, `{"stringkey":int,"intkey":int}`)
 		require.Error(t, err, `the value 'stringvalue' cannot be converted to an int`)
+	})
+}
+
+func TestLookup_all_invalid_type_map(t *testing.T) {
+	ensureTestPlugin(t)
+	inTestdata(func() {
+		_, err := cli.ExecuteLookup(`stringkey`, `intkey`, `--all`, `--dialect`, `dgo`, `--render-as`, `s`, `--type`, `string`)
+		require.Error(t, err, `type must be a map`)
 	})
 }
 

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -36,3 +36,7 @@ lookup_options:
     convert_to: Sensitive
 
 simple: value
+
+stringkey: stringvalue
+
+intkey: 1

--- a/lookup/testdata/hiera/common.yaml
+++ b/lookup/testdata/hiera/common.yaml
@@ -34,3 +34,5 @@ lookup_options:
     merge: deep
   sense:
     convert_to: Sensitive
+
+simple: value


### PR DESCRIPTION
Adds a new option `--multi-lookup` which will look up all of the keys and output the results as a map. This is drastically faster when using expensive plugins like Terraform remote state and you have a lot of keys to look up.