### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/hiera_docker.yaml
+++ b/.github/workflows/hiera_docker.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@master
     - name: Build and publish
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: lyraproj/hiera
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore